### PR TITLE
Update English.xml

### DIFF
--- a/Debug/Language/English.xml
+++ b/Debug/Language/English.xml
@@ -148,6 +148,9 @@
 		<Item English_Text = "Backup Database" ID = "32962"></Item>
 		<Item English_Text = "Restore Dastabase" ID = "32964"></Item>
 		
+		<Item English_Text = "Replace Top Sticky Clip" ID = "32938"></Item>
+		<Item English_Text = "Delete All Non Used Clips" ID = "32968"></Item>
+		<Item English_Text = "Set Drag File Name" ID = "32970"></Item>
 	</Ditto_Right_Click_Menu>
 	<Ditto_Clip_Properties>
 		<Item English_Text = "Hot Key" ID = "2039"></Item>
@@ -166,6 +169,7 @@
 		<Item English_Text = "Last Used" ID = "2043"></Item>
 		<Item English_Text = "Quick Paste Text" ID = "2125"></Item>
 				
+		<Item English_Text = "Selected format MD5" ID = "2167"></Item>
 	</Ditto_Clip_Properties>
 	<Ditto_Options_General>
 		<Item English_Text = "Start Ditto on System Startup" ID = "2004"></Item>
@@ -208,6 +212,11 @@
 		<Item English_Text = "Environment Variables" ID = "2165"></Item>
 		
 		<Item English_Text = "Default Font" ID = "2031"></Item>
+		
+		<Item English_Text = "Advanced" ID = "2124"></Item>
+		<Item English_Text = "At Caret" ID = "2015"></Item>
+		<Item English_Text = "At Cursor" ID = "2016"></Item>
+		<Item English_Text = "At Previous Position" ID = "2017"></Item>
 	</Ditto_Options_General>
 	<Ditto_Options_Supported_Types>
 		<Item English_Text = "Add" ID = "1015"></Item>
@@ -264,6 +273,7 @@
 		<Item English_Text = "Win" ID = "2065"></Item>
 		<Item English_Text = "Save Current Clipboard" ID = "2062"></Item>
 		<Item English_Text = "Win" ID = "2047"></Item>
+		<Item English_Text = "Copy And Save Current Clipboard" ID = "2068"></Item>
 		
 		<Item English_Text = "Use currently selected group in Ditto's UI for last ten copies" ID = "1044"></Item>
 		
@@ -319,6 +329,9 @@
 		<Item English_Text = "Add" ID = "1021"></Item>
 		<Item English_Text = "Cancel" ID = "2"></Item>
 		<Item English_Text = "Add Supported Type" ID = "-1"></Item>
+		<Item English_Text = "Current Clipboard Types" ID = "2128"></Item>
+		<Item English_Text = "Primary Clipboard Types" ID = "2145"></Item>
+		<Item English_Text = "Custom Clipboard Type" ID = "2130"></Item>
 	</Ditto_Options_Supported_Types_Add>
 	<Ditto_Move_To_Groups>
 		<Item English_Text = "New Group" ID = "1040"></Item>
@@ -398,7 +411,8 @@
 		<Item English_Text = "Hot Key" ID = "QPHotKey"></Item>
 		<Item English_Text = "Command" ID = "QPCommand"></Item>
 		
-		<Item English_Text = "[Always on top]" ID = "top_most"></Item>
+		//ID chenged from "top_most"
+		<Item English_Text = "[Always on top]" ID = "top_window"></Item>
 		
 		<Item English_Text = "[Disconnected]" ID = "disconnected"></Item>
 		<Item English_Text = "Ditto is running minimized, Ditto can be opened by hot keys or by clicking the task tray icon" ID = "StartuMsg"></Item>
@@ -446,6 +460,8 @@
 		
 		<Item English_Text = "Backup Database" ID = "32960"></Item>
 		<Item English_Text = "Restore Database" ID = "32961"></Item>
+		
+		<Item English_Text = "Delete All Non Used Clips" ID = "32969">
 		
 	</Ditto_Tray_Icon_Menu>
 
@@ -629,7 +645,43 @@
 		<Item English_Text = "Import Clip" ID = "82"></Item>
 		<Item English_Text = "Global HotKeys" ID = "83"></Item>
 		<Item English_Text = "Delete Clip Data" ID = "84"></Item>
-		<Item English_Text = "Replace Top Sticky Clip" ID = "85"></Item>		
+		<Item English_Text = "Replace Top Sticky Clip" ID = "85"></Item>
+		<Item English_Text = "Prompt send to friend" ID = "86"></Item>
+		<Item English_Text = "Save copied file (cf_hdrop) contents into Ditto" ID = "87"></Item>
+		<Item English_Text = "Toggle clipboard connection" ID = "88"></Item>
+		<Item English_Text = "Move Selection Up" ID = "89"></Item>
+		<Item English_Text = "Move Selection Down" ID = "90"></Item>
+		<Item English_Text = "Toggle Description Word Wrap" ID = "91"></Item>
+		<Item English_Text = "Apply Last Search" ID = "92"></Item>
+		<Item English_Text = "Toggle Search Method" ID = "93"></Item>
+		<Item English_Text = "Move Clip Last" ID = "95"></Item>
+		<Item English_Text = "Paste, Don't Change Clip Order" ID = "96"></Item>
+		<Item English_Text = "Paste, Trim White Space" ID = "97"></Item>
+		<Item English_Text = "Set Transparency None" ID = "98"></Item>
+		<Item English_Text = "Set Transparency 5%" ID = "99"></Item>
+		<Item English_Text = "Set Transparency 10%" ID = "100"></Item>
+		<Item English_Text = "Set Transparency 15%" ID = "101"></Item>
+		<Item English_Text = "Set Transparency 20%" ID = "102"></Item>
+		<Item English_Text = "Set Transparency 25%" ID = "103"></Item>
+		<Item English_Text = "Set Transparency 30%" ID = "104"></Item>
+		<Item English_Text = "Set Transparency 35%" ID = "105"></Item>
+		<Item English_Text = "Set Transparency 40%" ID = "106"></Item>
+		<Item English_Text = "Prompt send to friend" ID = "107"></Item>
+		<Item English_Text = "Increase Transparency %" ID = "108"></Item>
+		<Item English_Text = "Decrease Transparency %" ID = "109"></Item>
+		<Item English_Text = "EMail, Content In Body" ID = "110"></Item>
+		<Item English_Text = "EMail, Clip Export As Attachment" ID = "111"></Item>
+		<Item English_Text = "EMail, Content As Attachment" ID = "112"></Item>
+		<Item English_Text = "Gmail" ID = "113"></Item>
+		<Item English_Text = "Slugify" ID = "114"></Item>
+		<Item English_Text = "Invert Case" ID = "115"></Item>
+		<Item English_Text = "Copy Selection" ID = "116"></Item>
+		<Item English_Text = "Force Close Window" ID = "117"></Item>
+		<Item English_Text = "Refresh List" ID = "118"></Item>
+		<Item English_Text = "Delete all non used clips" ID = "119"></Item>
+		<Item English_Text = "Show System Context Menu" ID = "120"></Item>
+		<Item English_Text = "Set Drag File Name" ID = "121"></Item>
+		<Item English_Text = "Paste CamelCase" ID = "122"></Item>		
 	
 	</Ditto_Options_Quick_Paste_Keyboard>
 	

--- a/Debug/Language/English.xml
+++ b/Debug/Language/English.xml
@@ -168,7 +168,7 @@
 		<Item English_Text = "Hotkey available globally" ID = "1026"></Item>
 		<Item English_Text = "Last Used" ID = "2043"></Item>
 		<Item English_Text = "Quick Paste Text" ID = "2125"></Item>
-				
+		
 		<Item English_Text = "Selected format MD5" ID = "2167"></Item>
 	</Ditto_Clip_Properties>
 	<Ditto_Options_General>
@@ -425,7 +425,7 @@
 		<Item English_Text = "RestoreDbMsg" ID = "Restoring database"></Item>
 		
 		<Item English_Text = "Ditto was unable to open its database, waiting until it can be opened. Update the path in Options if needed. Path: " ID = "StartupNoDbMsg"></Item>
-				
+		
 		<Item English_Text = "At Caret" ID = "AtCaret"></Item>
 		<Item English_Text = "At Cursor" ID = "AtCursor"></Item>
 		<Item English_Text = "At Previous Position" ID = "AtPreviousPosition"></Item>
@@ -461,8 +461,7 @@
 		<Item English_Text = "Backup Database" ID = "32960"></Item>
 		<Item English_Text = "Restore Database" ID = "32961"></Item>
 		
-		<Item English_Text = "Delete All Non Used Clips" ID = "32969">
-		
+		<Item English_Text = "Delete All Non Used Clips" ID = "32969"></Item>
 	</Ditto_Tray_Icon_Menu>
 
 	//Added in 9-11-09
@@ -681,8 +680,8 @@
 		<Item English_Text = "Delete all non used clips" ID = "119"></Item>
 		<Item English_Text = "Show System Context Menu" ID = "120"></Item>
 		<Item English_Text = "Set Drag File Name" ID = "121"></Item>
-		<Item English_Text = "Paste CamelCase" ID = "122"></Item>		
-	
+		<Item English_Text = "Paste CamelCase" ID = "122"></Item>
+
 	</Ditto_Options_Quick_Paste_Keyboard>
 	
 </Ditto_Language_File>

--- a/Debug/Language/Japanese.xml
+++ b/Debug/Language/Japanese.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Ditto_Language_File Version = "3.22.70" Author = "Nardog, maboroshin" Notes = "for v3.22.72 ( update: 2019/11, errer no honyaku mikakunin, https://pc.genkaku.in/ )" LanguageCode="jpn">
+<Ditto_Language_File Version = "3.24.238" Author = "Nardog, maboroshin" Notes = "Update: 2022/10, errer no honyaku mikakunin, https://pc.genkaku.in/ )" LanguageCode="jpn">
 	<Ditto_Right_Click_Menu>
 		<Item English_Text = "Groups" ID = "-1">グループ(&amp;G)</Item>
 		<Item English_Text = "New Group	Ctrl-F7" ID = "32811">グループ作成(&amp;N)...</Item>
@@ -23,7 +23,7 @@
 		<Item English_Text = "35 " ID = "32950"></Item>
 		<Item English_Text = "40 " ID = "32790"></Item>
 		<Item English_Text = "Positioning" ID = "-1">表示位置(&amp;P)</Item>
-		<Item English_Text = "At Caret" ID = "32802">キャレット</Item>
+		<Item English_Text = "At Caret" ID = "32802">キャレット(&amp;C)</Item>
 		<Item English_Text = "At Cursor" ID = "32803">カーソル(&amp;M)</Item>
 		<Item English_Text = "At Previous Position" ID = "32804">前回の位置(&amp;P)</Item>
 		<Item English_Text = "First Ten Hot Keys" ID = "-1">最初の 10 個のホット キー</Item>
@@ -150,6 +150,8 @@
 		
 		//Added by maboroshin 2019/11
 		<Item English_Text = "Replace Top Sticky Clip" ID = "32938">クリップ付箋の先頭と入替(&amp;R)</Item>
+		<Item English_Text = "Delete All Non Used Clips" ID = "32968">未使用のクリップをすべて削除</Item>
+		<Item English_Text = "Set Drag File Name" ID = "32970">ドラッグ時のファイル名を設定</Item>
 	</Ditto_Right_Click_Menu>
 	<Ditto_Clip_Properties>
 		<Item English_Text = "Hot Key" ID = "2039">ホットキー</Item>
@@ -215,7 +217,7 @@
 		<Item English_Text = "Default Font" ID = "2031">既定のフォント</Item>
 		
 		//Added by maboroshin. 11/2019
-		<Item English_Text = "Advanced" ID = "2124">上級</Item>
+		<Item English_Text = "Advanced" ID = "2124">高度</Item>
 		<Item English_Text = "At Caret" ID = "2015">キャレット</Item>
 		<Item English_Text = "At Cursor" ID = "2016">カーソル</Item>
 		<Item English_Text = "At Previous Position" ID = "2017">前回の位置</Item>
@@ -275,6 +277,7 @@
 		<Item English_Text = "Win" ID = "2065"></Item>
 		<Item English_Text = "Save Current Clipboard" ID = "2062">現在のクリップボードを保存</Item>
 		<Item English_Text = "Win" ID = "2047"></Item>
+		<Item English_Text = "Copy And Save Current Clipboard" ID = "2068">現在のクリップボードをコピーして保存</Item>
 		
 		<Item English_Text = "Use currently selected group in Ditto's UI for last ten copies" ID = "1044">現在の選択しているグループの最近の10個を使用</Item>
 		
@@ -428,7 +431,11 @@
 		<Item English_Text = "BackupDbMsg" ID = "Backing up database">データベースをバックアップ中</Item>
 		<Item English_Text = "RestoreDbMsg" ID = "Restoring database">データベースを復元中</Item>
 		
-		
+		<Item English_Text = "Ditto was unable to open its database, waiting until it can be opened. Update the path in Options if needed. Path: " ID = "StartupNoDbMsg">Ditto がデータベースを開けないため、可能になるまで待機します。必要であれば、設定からパスを更新してください。パス: </Item>
+			
+		<Item English_Text = "At Caret" ID = "AtCaret">キャレット</Item>
+		<Item English_Text = "At Cursor" ID = "AtCursor">カーソル</Item>
+		<Item English_Text = "At Previous Position" ID = "AtPreviousPosition">前回の位置</Item>
 		
 	</Ditto_String_Table>
 	<Ditto_Options_Sheet>
@@ -461,6 +468,7 @@
 		<Item English_Text = "Backup Database" ID = "32960">データベースをバックアップ(&amp;B)...</Item>
 		<Item English_Text = "Restore Database" ID = "32961">データベースを復元(&amp;R)...</Item>
 		
+		<Item English_Text = "Delete All Non Used Clips" ID = "32969">未使用のクリップをすべて削除</Item>
 	</Ditto_Tray_Icon_Menu>
 
 	//Added in 9-11-09
@@ -677,6 +685,11 @@
 		<Item English_Text = "Invert Case" ID = "115">貼り付け/変換 小文字を反転</Item>
 		<Item English_Text = "Copy Selection" ID = "116">選択クリップをクリップボードにコピー</Item>
 		<Item English_Text = "Force Close Window" ID = "117">ウインドウを強制的に閉じる</Item>
+		<Item English_Text = "Refresh List" ID = "118">一覧の更新</Item>
+		<Item English_Text = "Delete all non used clips" ID = "119">未使用のクリップをすべて削除</Item>
+		<Item English_Text = "Show System Context Menu" ID = "120">システムの右クリックメニューを表示</Item>
+		<Item English_Text = "Set Drag File Name" ID = "121">ドラッグ時のファイル名を設定</Item>
+		<Item English_Text = "Paste CamelCase" ID = "122">貼り付け CamelCase</Item>
 	</Ditto_Options_Quick_Paste_Keyboard>
 	
 </Ditto_Language_File>

--- a/Debug/Language/Japanese.xml
+++ b/Debug/Language/Japanese.xml
@@ -411,7 +411,7 @@
 		<Item English_Text = "Hot Key" ID = "QPHotKey">ホットキー</Item>
 		<Item English_Text = "Command" ID = "QPCommand">コマンド</Item>
 		
-		//ID chenged from "top_most"
+		//ID chnged from "top_most"
 		<Item English_Text = "[Always on top]" ID = "top_window">[前面]</Item>
 		
 		<Item English_Text = "[Disconnected]" ID = "disconnected">[切断]</Item>

--- a/Debug/Language/Japanese.xml
+++ b/Debug/Language/Japanese.xml
@@ -148,7 +148,6 @@
 		<Item English_Text = "Backup Database" ID = "32962">データベースをバックアップ(&amp;B)...</Item>
 		<Item English_Text = "Restore Dastabase" ID = "32964">データベースを復元(&amp;R)...</Item>
 		
-		//Added by maboroshin 2019/11
 		<Item English_Text = "Replace Top Sticky Clip" ID = "32938">クリップ付箋の先頭と入替(&amp;R)</Item>
 		<Item English_Text = "Delete All Non Used Clips" ID = "32968">未使用のクリップをすべて削除</Item>
 		<Item English_Text = "Set Drag File Name" ID = "32970">ドラッグ時のファイル名を設定</Item>
@@ -170,9 +169,7 @@
 		<Item English_Text = "Last Used" ID = "2043">最終使用</Item>
 		<Item English_Text = "Quick Paste Text" ID = "2125">クイックペースト文</Item>
 		
-		//Added by maboroshin 2019/11
-		<Item English_Text = "Selected format MD5" ID = "2167">MD&amp;5:選択コピー形式</Item>
-				
+		<Item English_Text = "Selected format MD5" ID = "2167">選択した形式のMD5:</Item>
 	</Ditto_Clip_Properties>
 	<Ditto_Options_General>
 		<Item English_Text = "Start Ditto on System Startup" ID = "2004">システム起動時に Ditto を開始する</Item>
@@ -216,7 +213,6 @@
 		
 		<Item English_Text = "Default Font" ID = "2031">既定のフォント</Item>
 		
-		//Added by maboroshin. 11/2019
 		<Item English_Text = "Advanced" ID = "2124">高度</Item>
 		<Item English_Text = "At Caret" ID = "2015">キャレット</Item>
 		<Item English_Text = "At Cursor" ID = "2016">カーソル</Item>
@@ -333,12 +329,9 @@
 		<Item English_Text = "Add" ID = "1021">追加</Item>
 		<Item English_Text = "Cancel" ID = "2">キャンセル</Item>
 		<Item English_Text = "Add Supported Type" ID = "-1">対応形式の追加</Item>
-		
-		//New item added 12/17/16
 		<Item English_Text = "Current Clipboard Types" ID = "2128">現在のクリップボード形式</Item>
 		<Item English_Text = "Primary Clipboard Types" ID = "2145">主なクリップボード形式</Item>
 		<Item English_Text = "Custom Clipboard Type" ID = "2130">独自のクリップボード形式</Item>
-		
 	</Ditto_Options_Supported_Types_Add>
 	<Ditto_Move_To_Groups>
 		<Item English_Text = "New Group" ID = "1040">新規グループ(&amp;N)</Item>
@@ -418,7 +411,7 @@
 		<Item English_Text = "Hot Key" ID = "QPHotKey">ホットキー</Item>
 		<Item English_Text = "Command" ID = "QPCommand">コマンド</Item>
 		
-		//ID chenged from "top_most", by maboroshin. 11/2019
+		//ID chenged from "top_most"
 		<Item English_Text = "[Always on top]" ID = "top_window">[前面]</Item>
 		
 		<Item English_Text = "[Disconnected]" ID = "disconnected">[切断]</Item>
@@ -432,7 +425,7 @@
 		<Item English_Text = "RestoreDbMsg" ID = "Restoring database">データベースを復元中</Item>
 		
 		<Item English_Text = "Ditto was unable to open its database, waiting until it can be opened. Update the path in Options if needed. Path: " ID = "StartupNoDbMsg">Ditto がデータベースを開けないため、可能になるまで待機します。必要であれば、設定からパスを更新してください。パス: </Item>
-			
+		
 		<Item English_Text = "At Caret" ID = "AtCaret">キャレット</Item>
 		<Item English_Text = "At Cursor" ID = "AtCursor">カーソル</Item>
 		<Item English_Text = "At Previous Position" ID = "AtPreviousPosition">前回の位置</Item>
@@ -651,9 +644,7 @@
 		<Item English_Text = "Import Clip" ID = "82">クリップのインポート</Item>
 		<Item English_Text = "Global HotKeys" ID = "83">グローバルホットキー</Item>
 		<Item English_Text = "Delete Clip Data" ID = "84">クリップデータの削除</Item>
-		<Item English_Text = "Replace Top Sticky Clip" ID = "85">クリップ付箋を最初のものと入替</Item>		
-	
-		//Added by maboroshin. Nothig: 94  11/2019
+		<Item English_Text = "Replace Top Sticky Clip" ID = "85">クリップ付箋を最初のものと入替</Item>	
 		<Item English_Text = "Prompt send to friend" ID = "86">送信/宛先の入力</Item>
 		<Item English_Text = "Save copied file (cf_hdrop) contents into Ditto" ID = "87">CF_HDROP形式からファイルを保存</Item>
 		<Item English_Text = "Toggle clipboard connection" ID = "88">切替/クリップボード接続</Item>


### PR DESCRIPTION
Translators should also be added to the `English.xml` when you find them. I have confirmed that it appears in the Japanese translation.

I created an issue: https://github.com/sabrogden/Ditto/issues/350 (Unsupported strings for translation. Adding to xml does not translate.)