### PR TITLE
change default thumbnail interpolation mode to bicubic

### DIFF
--- a/AdvGeneral.cpp
+++ b/AdvGeneral.cpp
@@ -200,7 +200,7 @@ BOOL CAdvGeneral::OnInitDialog()
 	AddTrueFalse(pGroupTest, _T("Ensure Ditto is always connected to the clipboard"), CGetSetOptions::GetEnsureConnectToClipboard(), SETTING_ENSURE_CONNECTED);
 	AddTrueFalse(pGroupTest, _T("Ensure entire window is visible"), CGetSetOptions::GetEnsureEntireWindowCanBeSeen(), SETTING_ENSURE_WINDOW_IS_VISIBLE);
 
-	AddTrueFalse(pGroupTest, _T("Fast thumbnail mode (default: true means NearestNeighbor, low quality but fast. false means HighQualityBicubic, high quality but slow)"), CGetSetOptions::GetFastThumbnailMode(), SETTING_FAST_THUMBNAIL_MODE);
+	AddTrueFalse(pGroupTest, _T("Fast thumbnail mode (default: true means low quality but fast. false means high quality but slow)"), CGetSetOptions::GetFastThumbnailMode(), SETTING_FAST_THUMBNAIL_MODE);
 
 	AddTrueFalse(pGroupTest, _T("Find as you type"), CGetSetOptions::GetFindAsYouType(), SETTING_FIND_AS_TYPE);
 

--- a/BitmapHelper.cpp
+++ b/BitmapHelper.cpp
@@ -55,7 +55,6 @@ BOOL CBitmapHelper::GetCBitmap(void	*pClip2, CDC *pDC, CBitmap *pBitMap, int nMa
 	Gdiplus::Bitmap *gdipBitmap = pClip->CreateGdiplusBitmap();
 	if (gdipBitmap == NULL)
 	{
-		delete gdipBitmap;
 		return false;
 	}
 
@@ -86,7 +85,7 @@ BOOL CBitmapHelper::GetCBitmap(void	*pClip2, CDC *pDC, CBitmap *pBitMap, int nMa
 	Gdiplus::InterpolationMode interpolationMode = Gdiplus::InterpolationModeHighQualityBicubic;
 	if (CGetSetOptions::GetFastThumbnailMode())
 	{
-		interpolationMode = Gdiplus::InterpolationModeNearestNeighbor;
+		interpolationMode = Gdiplus::InterpolationModeBicubic;
 	}
 	graphics.SetInterpolationMode(interpolationMode);
 	graphics.SetCompositingMode(Gdiplus::CompositingModeSourceOver);


### PR DESCRIPTION
Following #585 I improved thumbnail mode more.
Nearest Neighbor mode is the fastest but has the lowest quality. Even though my eyesight isn't very good, I can still see it.
So, I tested other modes and found the point.
Normal Bicubic Mode is almost as fast as Nearest Neighbor and it's quality improved pretty more.