### PR TITLE
Add some options with some refactoring

### DIFF
--- a/AddType.cpp
+++ b/AddType.cpp
@@ -28,7 +28,7 @@ void CAddType::DoDataExchange(CDataExchange* pDX)
 {
 	CDialog::DoDataExchange(pDX);
 	//{{AFX_DATA_MAP(CAddType)
-	DDX_Control(pDX, IDC_LIST1, m_lbDefaultTypes);
+	DDX_Control(pDX, IDC_LIST1, m_lbCandidateTypes);
 	DDX_Text(pDX, IDC_EDIT1, m_eCustomType);
 	DDV_MaxChars(pDX, m_eCustomType, 50);
 	//}}AFX_DATA_MAP
@@ -54,7 +54,7 @@ BOOL CAddType::OnInitDialog()
 	::CheckDlgButton(m_hWnd, IDC_RADIO_CURRENT_TYPES, BST_CHECKED);
 	OnBnClickedRadioCurrentTypes();
 	
-	m_lbDefaultTypes.SetFocus();
+	m_lbCandidateTypes.SetFocus();
 
 	theApp.m_Language.UpdateOptionSupportedTypesAdd(this);
 	return FALSE;
@@ -62,7 +62,7 @@ BOOL CAddType::OnInitDialog()
 
 void CAddType::AddCurrentClipboardTypes()
 {
-	m_lbDefaultTypes.ResetContent();
+	m_lbCandidateTypes.ResetContent();
 
 	COleDataObject oleData;
 
@@ -76,7 +76,7 @@ void CAddType::AddCurrentClipboardTypes()
 	while (oleData.GetNextFormat(&test))
 	{
 		BOOL b = oleData.IsDataAvailable(test.cfFormat);
-		m_lbDefaultTypes.AddString(GetFormatName(test.cfFormat));
+		m_lbCandidateTypes.AddString(GetFormatName(test.cfFormat));
 	}
 
 	oleData.Release();
@@ -84,32 +84,32 @@ void CAddType::AddCurrentClipboardTypes()
 
 void CAddType::AddCommonTypes()
 {
-	m_lbDefaultTypes.ResetContent();
-	m_lbDefaultTypes.AddString(_T("CF_TEXT"));
-	m_lbDefaultTypes.AddString(_T("CF_BITMAP"));
-	m_lbDefaultTypes.AddString(_T("CF_METAFILEPICT"));
-	m_lbDefaultTypes.AddString(_T("CF_SYLK"));
-	m_lbDefaultTypes.AddString(_T("CF_DIF"));
-	m_lbDefaultTypes.AddString(_T("CF_TIFF"));
-	m_lbDefaultTypes.AddString(_T("CF_OEMTEXT"));
-	m_lbDefaultTypes.AddString(_T("CF_DIB"));
-	m_lbDefaultTypes.AddString(_T("CF_PALETTE"));
-	m_lbDefaultTypes.AddString(_T("CF_PENDATA"));
-	m_lbDefaultTypes.AddString(_T("CF_RIFF"));
-	m_lbDefaultTypes.AddString(_T("CF_WAVE"));
-	m_lbDefaultTypes.AddString(_T("CF_UNICODETEXT"));
-	m_lbDefaultTypes.AddString(_T("CF_ENHMETAFILE"));
-	m_lbDefaultTypes.AddString(_T("CF_HDROP"));
-	m_lbDefaultTypes.AddString(_T("CF_LOCALE"));
-	m_lbDefaultTypes.AddString(_T("CF_OWNERDISPLAY"));
-	m_lbDefaultTypes.AddString(_T("CF_DSPTEXT"));
-	m_lbDefaultTypes.AddString(_T("CF_DSPBITMAP"));
-	m_lbDefaultTypes.AddString(_T("CF_DSPMETAFILEPICT"));
-	m_lbDefaultTypes.AddString(_T("CF_DSPENHMETAFILE"));
-	m_lbDefaultTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RTF)));
-	m_lbDefaultTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RTFNOOBJS)));
-	m_lbDefaultTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RETEXTOBJ)));
-	m_lbDefaultTypes.AddString(GetFormatName(RegisterClipboardFormat(_T("HTML Format"))));
+	m_lbCandidateTypes.ResetContent();
+	m_lbCandidateTypes.AddString(_T("CF_TEXT"));
+	m_lbCandidateTypes.AddString(_T("CF_BITMAP"));
+	m_lbCandidateTypes.AddString(_T("CF_METAFILEPICT"));
+	m_lbCandidateTypes.AddString(_T("CF_SYLK"));
+	m_lbCandidateTypes.AddString(_T("CF_DIF"));
+	m_lbCandidateTypes.AddString(_T("CF_TIFF"));
+	m_lbCandidateTypes.AddString(_T("CF_OEMTEXT"));
+	m_lbCandidateTypes.AddString(_T("CF_DIB"));
+	m_lbCandidateTypes.AddString(_T("CF_PALETTE"));
+	m_lbCandidateTypes.AddString(_T("CF_PENDATA"));
+	m_lbCandidateTypes.AddString(_T("CF_RIFF"));
+	m_lbCandidateTypes.AddString(_T("CF_WAVE"));
+	m_lbCandidateTypes.AddString(_T("CF_UNICODETEXT"));
+	m_lbCandidateTypes.AddString(_T("CF_ENHMETAFILE"));
+	m_lbCandidateTypes.AddString(_T("CF_HDROP"));
+	m_lbCandidateTypes.AddString(_T("CF_LOCALE"));
+	m_lbCandidateTypes.AddString(_T("CF_OWNERDISPLAY"));
+	m_lbCandidateTypes.AddString(_T("CF_DSPTEXT"));
+	m_lbCandidateTypes.AddString(_T("CF_DSPBITMAP"));
+	m_lbCandidateTypes.AddString(_T("CF_DSPMETAFILEPICT"));
+	m_lbCandidateTypes.AddString(_T("CF_DSPENHMETAFILE"));
+	m_lbCandidateTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RTF)));
+	m_lbCandidateTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RTFNOOBJS)));
+	m_lbCandidateTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RETEXTOBJ)));
+	m_lbCandidateTypes.AddString(GetFormatName(RegisterClipboardFormat(_T("HTML Format"))));
 }
 
 void CAddType::OnBnClickedRadioPrimaryTypes()
@@ -117,11 +117,11 @@ void CAddType::OnBnClickedRadioPrimaryTypes()
 	AddCommonTypes();
 	::ShowWindow(::GetDlgItem(m_hWnd, IDC_LIST1), SW_SHOW);
 	::ShowWindow(::GetDlgItem(m_hWnd, IDC_EDIT1), SW_HIDE);
-	m_lbDefaultTypes.SetFocus();
-	if (m_lbDefaultTypes.GetCount() > 0)
+	m_lbCandidateTypes.SetFocus();
+	if (m_lbCandidateTypes.GetCount() > 0)
 	{
-		m_lbDefaultTypes.SetCurSel(0);
-		m_lbDefaultTypes.SetSel(0);
+		m_lbCandidateTypes.SetCurSel(0);
+		m_lbCandidateTypes.SetSel(0);
 	}
 }
 
@@ -130,11 +130,11 @@ void CAddType::OnBnClickedRadioCurrentTypes()
 	AddCurrentClipboardTypes();
 	::ShowWindow(::GetDlgItem(m_hWnd, IDC_LIST1), SW_SHOW);
 	::ShowWindow(::GetDlgItem(m_hWnd, IDC_EDIT1), SW_HIDE);
-	m_lbDefaultTypes.SetFocus();
-	if (m_lbDefaultTypes.GetCount() > 0)
+	m_lbCandidateTypes.SetFocus();
+	if (m_lbCandidateTypes.GetCount() > 0)
 	{
-		m_lbDefaultTypes.SetCurSel(0);
-		m_lbDefaultTypes.SetSel(0);
+		m_lbCandidateTypes.SetCurSel(0);
+		m_lbCandidateTypes.SetSel(0);
 
 	}
 }
@@ -153,17 +153,17 @@ void CAddType::OnBnClickedAdd()
 	if (IsDlgButtonChecked(IDC_RADIO_PRIMARY_TYPES) == BST_CHECKED ||
 		IsDlgButtonChecked(IDC_RADIO_CURRENT_TYPES) == BST_CHECKED)
 	{
-		int nCount = m_lbDefaultTypes.GetSelCount();
+		int nCount = m_lbCandidateTypes.GetSelCount();
 		if (nCount)
 		{
 			CString cs;
 			CArray<int, int> items;
 			items.SetSize(nCount);
-			m_lbDefaultTypes.GetSelItems(nCount, items.GetData());
+			m_lbCandidateTypes.GetSelItems(nCount, items.GetData());
 
 			for (int i = 0; i < nCount; i++)
 			{
-				m_lbDefaultTypes.GetText(items[i], cs);
+				m_lbCandidateTypes.GetText(items[i], cs);
 				m_csSelectedTypes.Add(cs);
 			}
 		}

--- a/AddType.cpp
+++ b/AddType.cpp
@@ -3,6 +3,7 @@
 
 #include "stdafx.h"
 #include "cp_main.h"
+#include "Misc.h"
 #include "AddType.h"
 
 #ifdef _DEBUG
@@ -85,27 +86,9 @@ void CAddType::AddCurrentClipboardTypes()
 void CAddType::AddCommonTypes()
 {
 	m_lbCandidateTypes.ResetContent();
-	m_lbCandidateTypes.AddString(_T("CF_TEXT"));
-	m_lbCandidateTypes.AddString(_T("CF_BITMAP"));
-	m_lbCandidateTypes.AddString(_T("CF_METAFILEPICT"));
-	m_lbCandidateTypes.AddString(_T("CF_SYLK"));
-	m_lbCandidateTypes.AddString(_T("CF_DIF"));
-	m_lbCandidateTypes.AddString(_T("CF_TIFF"));
-	m_lbCandidateTypes.AddString(_T("CF_OEMTEXT"));
-	m_lbCandidateTypes.AddString(_T("CF_DIB"));
-	m_lbCandidateTypes.AddString(_T("CF_PALETTE"));
-	m_lbCandidateTypes.AddString(_T("CF_PENDATA"));
-	m_lbCandidateTypes.AddString(_T("CF_RIFF"));
-	m_lbCandidateTypes.AddString(_T("CF_WAVE"));
-	m_lbCandidateTypes.AddString(_T("CF_UNICODETEXT"));
-	m_lbCandidateTypes.AddString(_T("CF_ENHMETAFILE"));
-	m_lbCandidateTypes.AddString(_T("CF_HDROP"));
-	m_lbCandidateTypes.AddString(_T("CF_LOCALE"));
-	m_lbCandidateTypes.AddString(_T("CF_OWNERDISPLAY"));
-	m_lbCandidateTypes.AddString(_T("CF_DSPTEXT"));
-	m_lbCandidateTypes.AddString(_T("CF_DSPBITMAP"));
-	m_lbCandidateTypes.AddString(_T("CF_DSPMETAFILEPICT"));
-	m_lbCandidateTypes.AddString(_T("CF_DSPENHMETAFILE"));
+	for (auto systemClipFormat : GetSystemClipFormats()) {
+		m_lbCandidateTypes.AddString(GetFormatName(systemClipFormat));
+	}
 	m_lbCandidateTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RTF)));
 	m_lbCandidateTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RTFNOOBJS)));
 	m_lbCandidateTypes.AddString(GetFormatName(RegisterClipboardFormat(CF_RETEXTOBJ)));

--- a/AddType.h
+++ b/AddType.h
@@ -19,7 +19,7 @@ public:
 // Dialog Data
 	//{{AFX_DATA(CAddType)
 	enum { IDD = IDD_ADD_TYPE };
-	CListBox	m_lbDefaultTypes;
+	CListBox	m_lbCandidateTypes;
 	CString	m_eCustomType;
 	//}}AFX_DATA
 

--- a/AdvGeneral.cpp
+++ b/AdvGeneral.cpp
@@ -259,7 +259,7 @@ BOOL CAdvGeneral::OnInitDialog()
 	AddTrueFalse(pGroupTest, _T("Show startup tooltip message"), CGetSetOptions::GetShowStartupMessage(), SETTING_SHOW_STARTUP_MESSAGE);
 
 	AddTrueFalse(pGroupTest, _T("Show text for first ten copy hot keys"), CGetSetOptions::GetShowTextForFirstTenHotKeys(), SETTING_TEXT_FIRST_TEN);
-	AddTrueFalse(pGroupTest, _T("Show thumbnails(for CF_DIB types) (could increase memory usage and display speed)"), CGetSetOptions::GetDrawThumbnail(), SETTING_DRAW_THUMBNAILS);
+	AddTrueFalse(pGroupTest, _T("Show thumbnails(for CF_DIB and PNG types) (could increase memory usage and display speed)"), CGetSetOptions::GetDrawThumbnail(), SETTING_DRAW_THUMBNAILS);
 	
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Slugify Separator (default: -)"), CGetSetOptions::GetSlugifySeparator(), _T(""), SETTING_SLUGIFY_SEPARATOR));
 

--- a/AdvGeneral.cpp
+++ b/AdvGeneral.cpp
@@ -141,6 +141,7 @@ END_MESSAGE_MAP()
 #define SETTING_SLUGIFY_SEPARATOR 90
 #define SETTING_FAST_THUMBNAIL_MODE 91
 #define SETTING_CLIPBOARD_RESTORE_AFTER_COPY_BUFFER_DELAY 92
+#define SETTING_SUPPORT_ALL_TYPES 93
 
 BOOL CAdvGeneral::OnInitDialog()
 {
@@ -180,6 +181,8 @@ BOOL CAdvGeneral::OnInitDialog()
 	AddTrueFalse(pGroupTest, _T("Always show scroll bar"), CGetSetOptions::GetShowScrollBar(), SETTING_ALWAYS_SHOW_SCROLL_BAR);
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Amount of text to save for description"), g_Opt.m_bDescTextSize, _T(""), SETTING_DESC_SIZE));
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Copy and save clipboard delay (ms)"), (long)CGetSetOptions::GetCopyAndSveDelay(), _T(""), SETTING_COPY_SAVE_DELAY));
+	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Clipboard restore delay after copy buffer sent paste (ms, default: 750))"), (long)(CGetSetOptions::GetDittoRestoreClipboardDelay()), _T(""), SETTING_CLIPBOARD_RESTORE_AFTER_COPY_BUFFER_DELAY));
+
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Default paste string"), CGetSetOptions::GetDefaultPasteString(), _T(""), SETTING_DEFAULT_PASTE_STRING));
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Default copy string"), CGetSetOptions::GetDefaultCopyString(), _T(""), SETTING_DEFAULT_COPY_STRING));
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Default cut string"), CGetSetOptions::GetDefaultCutString(), _T(""), SETTING_DEFAULT_CUT_STRING));
@@ -237,8 +240,6 @@ BOOL CAdvGeneral::OnInitDialog()
 
 	AddTrueFalse(pGroupTest, _T("Refresh view after paste"), CGetSetOptions::GetRefreshViewAfterPasting(), SETTING_REFRESH_VIEW_AFTER_PASTE);
 
-	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("clipboard restore after copy buffer sent paste delay (ms, default: 750))"), (long)(CGetSetOptions::GetDittoRestoreClipboardDelay()), _T(""), SETTING_CLIPBOARD_RESTORE_AFTER_COPY_BUFFER_DELAY));
-
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Save clipboard delay (ms, default: 100))"), (long)(CGetSetOptions::GetProcessDrawClipboardDelay()), _T(""), SETTING_CLIPBOARD_SAVE_DELAY));
 
 	AddTrueFalse(pGroupTest, _T("Save multi-pastes"), CGetSetOptions::GetSaveMultiPaste(), SETTING_SAVE_MULTI_PASTE);
@@ -261,6 +262,8 @@ BOOL CAdvGeneral::OnInitDialog()
 	AddTrueFalse(pGroupTest, _T("Show thumbnails(for CF_DIB types) (could increase memory usage and display speed)"), CGetSetOptions::GetDrawThumbnail(), SETTING_DRAW_THUMBNAILS);
 	
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Slugify Separator (default: -)"), CGetSetOptions::GetSlugifySeparator(), _T(""), SETTING_SLUGIFY_SEPARATOR));
+
+	AddTrueFalse(pGroupTest, _T("Support all types ignoring supported type list (default: false))"), CGetSetOptions::GetSupportAllTypes(), SETTING_SUPPORT_ALL_TYPES);
 
 	pGroupTest->AddSubItem(new CMFCPropertyGridProperty(_T("Text lines per clip"), CGetSetOptions::GetLinesPerRow(), _T(""), SETTING_LINES_PER_ROW));
 
@@ -372,44 +375,28 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_SHOW_TASKBAR_ICON:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowIconInSysTray(val);
 				}
 				break;
 			case SETTING_SAVE_MULTI_PASTE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetSaveMultiPaste(val);
 				}
 				break;
 			case SETTING_HIDE_ON_HOTKEY_IF_VISIBLE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetHideDittoOnHotKeyIfAlreadyShown(val);
 				}
 				break;
 			case SETTING_PASTE_IN_ACTIVE_WINDOW:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetSendPasteAfterSelection(val);
 				}
 				break;
@@ -429,11 +416,7 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_ENSURE_CONNECTED:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetEnsureConnectToClipboard(val);
 				}
 				break;
@@ -446,22 +429,14 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_TEXT_FIRST_TEN:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowTextForFirstTenHotKeys(val);
 				}
 				break;
 			case SETTING_SHOW_LEADING_WHITESPACE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetDescShowLeadingWhiteSpace(val);
 				}
 				break;
@@ -474,11 +449,7 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_ENABLE_TRANSPARENCY:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetEnableTransparency(val);
 				}
 				break;
@@ -497,132 +468,84 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_DRAW_THUMBNAILS:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetDrawThumbnail(val);
 				}
 				break;
 			case SETTING_FAST_THUMBNAIL_MODE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetFastThumbnailMode(val);
 				}
 				break;
 			case SETTING_DRAW_RTF:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetDrawRTF(val);
 				}
 				break;
 			case SETTING_FIND_AS_TYPE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetFindAsYouType(val);
 				}
 				break;
 			case SETTING_ENSURE_WINDOW_IS_VISIBLE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetEnsureEntireWindowCanBeSeen(val);
 				}
 				break;
 			case SETTING_SHOW_GROUP_CLIPS_IN_LIST:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowAllClipsInMainList(val);
 				}
 				break;
 			case SETTING_PROMPT_ON_DELETE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetPromptWhenDeletingClips(val);
 				}
 				break;
 			case SETTING_ALWAYS_SHOW_SCROLL_BAR:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowScrollBar(val);
 				}
 				break;
 			case SETTING_PASTE_AS_ADMIN:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetPasteAsAdmin(val);
 				}
 				break;
 			case SETTTING_SHOW_IN_TASKBAR:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowInTaskBar(val);
 				}
 				break;
 			case SETTING_SHOW_CLIP_PASTED:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowIfClipWasPasted(val);
 				}
 				break;
 			case SETTING_SHOW_MSG_WHEN_RECEIVING_MANUAL_SENT_CLIP:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowMsgWhenReceivingManualSentClip(val);
 				}
 				break;
@@ -635,55 +558,35 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_UPDATE_ORDER_ON_PASTE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetUpdateTimeOnPaste(val);
 				}
 				break;
 			case SETTING_UPDATE_ORDER_ON_CTRL_C:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetUpdateClipOrderOnCtrlC(val);
 				}
 				break;
 			case SETTING_MULTIPASTE_REVERSE_ORDER:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetMultiPasteReverse(val);
 				}
 				break;
 			case SETTING_ALLOW_DUPLICATES:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetAllowDuplicates(val);
 				}
 				break;
 			case SETTING_ALOW_BACK_TO_BACK_DUPLICATES:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetAllowBackToBackDuplicates(val);
 				}
 				break;
@@ -731,11 +634,7 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_SHOW_STARTUP_MESSAGE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetShowStartupMessage(val);
 				}
 				break;
@@ -788,11 +687,7 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_REVERT_TO_TOP_LEVEL_GROUP:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetRevertToTopLevelGroup(val);
 				}
 				break;
@@ -835,11 +730,7 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_OPEN_TO_GROUP_AS_ACTIVE_EXE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetOpenToGroupByActiveExe(val);
 				}
 				break;
@@ -847,11 +738,7 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_ADD_CF_HDROP_ON_DRAG:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetAddCFHDROP_OnDrag(val);
 				}
 				break;
@@ -870,22 +757,14 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_MOVE_SELECTION_ON_OPEN_HOTKEY:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetMoveSelectionOnOpenHotkey(val);
 				}
 				break;
 			case SETTING_MAINTAIN_SEARCH_VIEW:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetMaintainSearchView(val);
 				}
 				break;
@@ -898,22 +777,14 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_DEBUG_TO_FILE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetEnableDebugLogging(val);
 				}
 				break;
 			case SETTING_DEBUG_TO_OUTPUT_STRING:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetEnableOutputDebugStringLogging(val);
 				}
 				break;
@@ -926,11 +797,7 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_DISABLE_FRIENDS:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = true;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = false;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetAllowFriends(val);
 				}
 				break;
@@ -943,14 +810,18 @@ void CAdvGeneral::OnBnClickedOk()
 			case SETTING_REFRESH_VIEW_AFTER_PASTE:
 				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
 				{
-					BOOL val = false;
-					if (wcscmp(pNewValue->bstrVal, L"True") == 0)
-					{
-						val = true;
-					}
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
 					CGetSetOptions::SetRefreshViewAfterPasting(val);
 				}
 				break;
+			case SETTING_SUPPORT_ALL_TYPES:
+				if (wcscmp(pNewValue->bstrVal, pOrigValue->bstrVal) != 0)
+				{
+					BOOL val = wcscmp(pNewValue->bstrVal, L"True") == 0;
+					CGetSetOptions::SetSupportAllTypes(val);
+				}
+				break;
+
 			}
 		}
 	}

--- a/CP_Main.cpp
+++ b/CP_Main.cpp
@@ -671,6 +671,7 @@ CClipTypes* CCP_MainApp::LoadTypesFromDB()
 		pTypes->Add(CF_HDROP);
 		pTypes->Add(CF_DIB);
 		pTypes->Add(GetFormatID(_T("HTML Format")));
+		pTypes->Add(GetFormatID(_T("PNG")));
 	}
 
 	return pTypes;

--- a/CP_Main.vcxproj
+++ b/CP_Main.vcxproj
@@ -759,6 +759,7 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="ICU_String.cpp" />
+    <ClCompile Include="ImageHelper.cpp" />
     <ClCompile Include="NoDbFrameWnd.cpp" />
     <ClCompile Include="CopyProperties.cpp">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Disabled</Optimization>
@@ -2905,6 +2906,7 @@
     <ClInclude Include="ClipCompare.h" />
     <ClInclude Include="ClipFormatQListCtrl.h" />
     <ClInclude Include="ICU_String.h" />
+    <ClInclude Include="ImageHelper.h" />
     <ClInclude Include="NoDbFrameWnd.h" />
     <ClInclude Include="CreateQRCodeImage.h" />
     <ClInclude Include="CustomFriendsHelper.h" />

--- a/CP_Main.vcxproj.filters
+++ b/CP_Main.vcxproj.filters
@@ -471,6 +471,7 @@
       <Filter>source</Filter>
     </ClCompile>
     <ClCompile Include="ImageFormatAggregator.cpp" />
+    <ClCompile Include="ImageHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="sqlite\CppSQLite3.h">
@@ -979,6 +980,7 @@
       <Filter>header</Filter>
     </ClInclude>
     <ClInclude Include="ImageFormatAggregator.h" />
+    <ClInclude Include="ImageHelper.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="CP_Main.rc">

--- a/Clip.cpp
+++ b/Clip.cpp
@@ -348,8 +348,14 @@ bool CClip::AddFormat(CLIPFORMAT cfType, void* pData, UINT nLen, bool setDesc)
 // Fills this CClip with the contents of the clipboard.
 int CClip::LoadFromClipboard(CClipTypes* pClipTypes, bool checkClipboardIgnore, CString activeApp, CString activeAppTitle)
 {
+	if(pClipTypes == NULL || pClipTypes->GetSize() == 0)
+	{
+		ASSERT(0); // this feature is not currently used... it is an error if it is.
+		Log(_T("no types were given to accept, skipping this clipboard change"));
+		return FALSE;
+	}
+
 	COleDataObjectEx oleData;
-	CClipTypes defaultTypes;
 	CClipTypes* pTypes = pClipTypes;
 
 	// m_Formats should be empty when this is called.
@@ -380,18 +386,6 @@ int CClip::LoadFromClipboard(CClipTypes* pClipTypes, bool checkClipboardIgnore, 
 	
 	oleData.EnsureClipboardObject();
 	
-	// if no types were given, get only the first (most important) type.
-	//  (subsequent types could be synthetic due to automatic type conversions)
-	if(pTypes == NULL || pTypes->GetSize() == 0)
-	{
-		ASSERT(0); // this feature is not currently used... it is an error if it is.
-		
-		FORMATETC formatEtc;
-		oleData.BeginEnumFormats();
-		oleData.GetNextFormat(&formatEtc);
-		defaultTypes.Add(formatEtc.cfFormat);
-		pTypes = &defaultTypes;
-	}
 	
 	m_Desc = "[Ditto Error] BAD DESCRIPTION";
 	

--- a/Clip.cpp
+++ b/Clip.cpp
@@ -110,13 +110,13 @@ std::shared_ptr<CClipTypes> COleDataObjectEx::GetAvailableTypes()
 	if (!OpenClipboard(theApp.m_MainhWnd))
 		return types;
 
-	int format = EnumClipboardFormats(0);
+	int format = 0;
 	do
 	{
 		format = EnumClipboardFormats(format);
 		// Currently CF_MAX is not valid format
 		// See https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
-		if (format == CF_MAX)
+		if (format == 0 || format == CF_MAX)
 			continue;
 		types->Add(format);
 	} while (format != 0);

--- a/Clip.h
+++ b/Clip.h
@@ -1,4 +1,4 @@
-// ProcessCopy.h: classes for saving the clipboard to db
+// Clip.h: classes for manage clips
 //
 //////////////////////////////////////////////////////////////////////
 
@@ -10,6 +10,7 @@
 #endif // _MSC_VER > 1000
 #include <afxole.h>
 #include <afxtempl.h>
+#include <memory>
 #include "tinyxml\tinyxml.h"
 #include "Shared\IClip.h"
 #include "Misc.h"
@@ -27,6 +28,7 @@ class COleDataObjectEx : public COleDataObject
 public:
 	// creates global from IStream if necessary
 	HGLOBAL GetGlobalData(CLIPFORMAT cfFormat, LPFORMATETC lpFormatEtc = NULL);
+	std::shared_ptr<CClipTypes> GetAvailableTypes();
 };
 
 /*----------------------------------------------------------------------------*\

--- a/ExternalWindowTracker.cpp
+++ b/ExternalWindowTracker.cpp
@@ -227,7 +227,19 @@ void ExternalWindowTracker::SendPaste(bool activateTarget)
 	CSendKeys send;
 	send.AllKeysUp();
 
-	if(activateTarget == false)
+	if(activateTarget)
+	{
+		DWORD startTick = GetTickCount();
+
+		ActivateTarget();
+		theApp.PumpMessageEx();
+		WaitForActiveWnd(activeWnd, max(25, g_Opt.WaitForActiveWndTimeout()));
+	
+		DWORD endTick = GetTickCount();
+		if((endTick-startTick) > 150)
+			Log(StrF(_T("Paste Timing Send Paste around activate Target: %d"), endTick-startTick));
+	}
+	else
 	{
 		activeWnd = ::GetForegroundWindow();
 	}
@@ -236,19 +248,6 @@ void ExternalWindowTracker::SendPaste(bool activateTarget)
 	CString csPasteString = g_Opt.GetPasteString(csPasteToApp);
 	DWORD delay = g_Opt.SendKeysDelay();
 	DWORD sendKeysDelay = g_Opt.RealSendKeysDelay();
-
-	DWORD startTick = GetTickCount();
-
-	if(activateTarget)
-	{
-		ActivateTarget();
-		theApp.PumpMessageEx();
-		WaitForActiveWnd(activeWnd, max(25, g_Opt.WaitForActiveWndTimeout()));
-	}
-
-	DWORD endTick = GetTickCount();
-	if((endTick-startTick) > 150)
-		Log(StrF(_T("Paste Timing Send Paste around activate Target: %d"), endTick-startTick));
 
 	m_dittoHasFocus = false;
 	Log(StrF(_T("Sending paste to app %s key stroke: %s, SeDelay: %d"), csPasteToApp, csPasteString, delay));

--- a/ImageHelper.cpp
+++ b/ImageHelper.cpp
@@ -1,0 +1,20 @@
+#include "stdafx.h"
+#include "ImageHelper.h"
+
+void DIBImageHelper::prependStream(IStream* pIStream, LPVOID pvData, ULONG size)
+{
+	BITMAPINFO* lpBI = (BITMAPINFO*)pvData;
+
+	int nPaletteEntries = 1 << lpBI->bmiHeader.biBitCount;
+	if (lpBI->bmiHeader.biBitCount > 8)
+		nPaletteEntries = 0;
+	else if (lpBI->bmiHeader.biClrUsed != 0)
+		nPaletteEntries = lpBI->bmiHeader.biClrUsed;
+
+	BITMAPFILEHEADER BFH;
+	memset(&BFH, 0, sizeof(BITMAPFILEHEADER));
+	BFH.bfType = 'MB';
+	BFH.bfSize = sizeof(BITMAPFILEHEADER) + size;
+	BFH.bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + nPaletteEntries * sizeof(RGBQUAD);
+	pIStream->Write(&BFH, sizeof(BITMAPFILEHEADER), NULL);
+}

--- a/ImageHelper.h
+++ b/ImageHelper.h
@@ -1,0 +1,59 @@
+#include "stdafx.h"
+#include "Misc.h"
+#include <memory>
+
+template <class Concrete, class GdipImage>
+class ImageHelper abstract
+{
+public:
+	static GdipImage* GdipImageFromHGLOBAL(HGLOBAL hGlobal) {
+		IStream* pIStream = StreamFromHGLOBAL(hGlobal);
+		if (!pIStream)
+			return NULL;
+
+		GdipImage* gdipImage = GdipImage::FromStream(pIStream);
+		pIStream->Release();
+		return gdipImage;
+	};
+	static std::shared_ptr<CImage> CImageFromHGLOBAL(HGLOBAL hGlobal) {
+		IStream* pIStream = StreamFromHGLOBAL(hGlobal);
+		if (!pIStream)
+			return NULL;
+
+		std::shared_ptr<CImage> cImage = std::make_shared<CImage>();
+		cImage->Load(pIStream);
+		pIStream->Release();
+
+		return cImage;
+	};
+	static IStream* StreamFromHGLOBAL(HGLOBAL hGlobal) {
+		if (!hGlobal)
+			return NULL;
+
+		IStream* pIStream = NULL;
+		if (CreateStreamOnHGlobal(NULL, TRUE, (LPSTREAM*)&pIStream) != S_OK)
+			return NULL;
+
+		LPVOID pvData = GlobalLock(hGlobal);
+		ULONG size = (ULONG)GlobalSize(hGlobal);
+
+		Concrete::prependStream(pIStream, pvData, size);
+
+		pIStream->Write(pvData, size, NULL);
+		GlobalUnlock(hGlobal);
+
+		return pIStream;
+	};
+};
+
+class PNGImageHelper : public ImageHelper<PNGImageHelper, Gdiplus::Bitmap>
+{
+public:
+	static void prependStream(IStream* pIStream, LPVOID pvData, ULONG size) {};
+};
+
+class DIBImageHelper : public ImageHelper<DIBImageHelper, Gdiplus::Bitmap>
+{
+public:
+	static void prependStream(IStream* pIStream, LPVOID pvData, ULONG size);
+};

--- a/ImageHelper.h
+++ b/ImageHelper.h
@@ -46,10 +46,14 @@ public:
 	};
 };
 
-class PNGImageHelper : public ImageHelper<PNGImageHelper, Gdiplus::Bitmap>
+class BitmapImageHelper : public ImageHelper<BitmapImageHelper, Gdiplus::Bitmap>
 {
 public:
 	static void prependStream(IStream* pIStream, LPVOID pvData, ULONG size) {};
+};
+
+class PNGImageHelper : public BitmapImageHelper
+{
 };
 
 class DIBImageHelper : public ImageHelper<DIBImageHelper, Gdiplus::Bitmap>

--- a/Misc.cpp
+++ b/Misc.cpp
@@ -10,6 +10,7 @@
 #include <sys/stat.h> 
 #include "Path.h"
 #include <regex>
+#include <vector>
 
 CString GetIPAddress()
 {
@@ -383,6 +384,35 @@ int CompareGlobalHH( HGLOBAL hLeft, HGLOBAL hRight, SIZE_T ulBufLen)
 	return result;
 }
 
+// https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
+std::vector<CLIPFORMAT> GetSystemClipFormats()
+{
+	std::vector<CLIPFORMAT> v = {
+		CF_TEXT,
+		CF_BITMAP,
+		CF_METAFILEPICT,
+		CF_SYLK,
+		CF_DIF,
+		CF_TIFF,
+		CF_OEMTEXT,
+		CF_DIB,
+		CF_PALETTE,
+		CF_PENDATA,
+		CF_RIFF,
+		CF_WAVE,
+		CF_UNICODETEXT,
+		CF_ENHMETAFILE,
+		CF_HDROP,
+		CF_LOCALE,
+		CF_OWNERDISPLAY,
+		CF_DSPTEXT,
+		CF_DSPBITMAP,
+		CF_DSPMETAFILEPICT,
+		CF_DSPENHMETAFILE
+	};
+
+	return v;
+}
 
 //Do not change these these are stored in the database
 CLIPFORMAT GetFormatID(LPCTSTR cbName)

--- a/Misc.h
+++ b/Misc.h
@@ -7,6 +7,7 @@
 #endif // _MSC_VER > 1000
 
 #include "Shared/ArrayEx.h"
+#include <vector>
 
 #define VK_MOUSE_CLICK 0x01
 #define VK_MOUSE_DOUBLE_CLICK 0x02
@@ -112,6 +113,7 @@ BOOL DecryptString(UCHAR *pData, int nLenIn, UCHAR*& pOutput, int &nLenOutput);
 int GetScreenWidth();
 int GetScreenHeight();
 
+std::vector<CLIPFORMAT> GetSystemClipFormats();
 CLIPFORMAT GetFormatID(LPCTSTR cbName);
 CString GetFormatName(CLIPFORMAT cbType);
 BOOL PreTranslateGuiDll(MSG *pMsg);

--- a/OleClipSource.cpp
+++ b/OleClipSource.cpp
@@ -1283,56 +1283,49 @@ HGLOBAL COleClipSource::ConvertToFileDrop()
 
 			fileClip.WriteTextToFile(file, TRUE, FALSE, FALSE);
 			fileList.AddFile(file);
+			continue;
 		}
-		else
-		{
-			CClipFormat *asciiText = fileClip.m_Formats.FindFormat(CF_TEXT);
-			if (asciiText)
-			{
-				CString name = _T("text");
-				CString file;
-				if (customDragName != _T(""))
-				{
-					name = customDragName;
-					file.Format(_T("%s%s.txt"), path, name);
-				}
-				else
-				{
-					file.Format(_T("%s%s_%d.txt"), path, name, dragId++);
-				}
 
-				fileClip.WriteTextToFile(file, FALSE, TRUE, FALSE);
-				fileList.AddFile(file);
+		CClipFormat *asciiText = fileClip.m_Formats.FindFormat(CF_TEXT);
+		if (asciiText)
+		{
+			CString name = _T("text");
+			CString file;
+			if (customDragName != _T(""))
+			{
+				name = customDragName;
+				file.Format(_T("%s%s.txt"), path, name);
 			}
 			else
 			{
-				CClipFormat *png = NULL;
-				CClipFormat *bitmap = fileClip.m_Formats.FindFormat(CF_DIB);
-				if (bitmap == NULL)
-				{
-					png = fileClip.m_Formats.FindFormat(theApp.m_PNG_Format);
-				}
+				file.Format(_T("%s%s_%d.txt"), path, name, dragId++);
+			}
 
-				if (bitmap != NULL ||
-					png != NULL)
-				{
-					CString name = _T("image");
-					CString file;
-					if (customDragName != _T(""))
-					{
-						name = customDragName;
-						file.Format(_T("%s%s.png"), path, name);
-					}
-					else
-					{
-						file.Format(_T("%s%s_%d.png"), path, name, dragId++);
-					}
+			fileClip.WriteTextToFile(file, FALSE, TRUE, FALSE);
+			fileList.AddFile(file);
+			continue;
+		}
 
-					if (fileClip.WriteImageToFile(file))
-					{
-						fileList.AddFile(file);
-					}
-				}
+		CClipFormat *png = fileClip.m_Formats.FindFormat(theApp.m_PNG_Format);
+		CClipFormat *bitmap = fileClip.m_Formats.FindFormat(CF_DIB);
+		if (bitmap != NULL ||
+			png != NULL)
+		{
+			CString name = _T("image");
+			CString file;
+			if (customDragName != _T(""))
+			{
+				name = customDragName;
+				file.Format(_T("%s%s.png"), path, name);
+			}
+			else
+			{
+				file.Format(_T("%s%s_%d.png"), path, name, dragId++);
+			}
+
+			if (fileClip.WriteImageToFile(file))
+			{
+				fileList.AddFile(file);
 			}
 		}
 	}

--- a/Options.cpp
+++ b/Options.cpp
@@ -1915,11 +1915,6 @@ CString CGetSetOptions::GetPasteString(CString csAppName)
 	CString csString = GetProfileString(csAppName, _T(""), _T("PasteStrings"));
 	if (csString.IsEmpty())
 	{
-		//edge is really slow to set focus so add a delay before sending the paste
-		if (csAppName == L"MicrosoftEdge.exe")
-		{
-			return _T("{DELAY 500}^{VKEY86}");
-		}
 		return GetDefaultPasteString();
 	}
 

--- a/Options.cpp
+++ b/Options.cpp
@@ -83,6 +83,7 @@ BOOL CGetSetOptions::m_maintainSearchView = FALSE;
 CString CGetSetOptions::m_tempDragFileName = "";
 CTime CGetSetOptions::m_tempDragFileNameSetTime;
 BOOL CGetSetOptions::m_refreshViewAfterPasting = TRUE;
+BOOL CGetSetOptions::m_supportAllTypes = FALSE;
 
 
 CGetSetOptions::CGetSetOptions()
@@ -2982,3 +2983,13 @@ void CGetSetOptions::SetSlugifySeparator(CString val)
 	SetProfileString("SlugifySeparator", val);
 }
 
+BOOL CGetSetOptions::GetSupportAllTypes()
+{
+	return GetProfileLong("SupportAllTypes", FALSE);
+}
+
+void CGetSetOptions::SetSupportAllTypes(BOOL val)
+{
+	m_refreshViewAfterPasting = val;
+	SetProfileLong("SupportAllTypes", val);
+}

--- a/Options.h
+++ b/Options.h
@@ -676,6 +676,10 @@ public:
 
 	static CString GetSlugifySeparator();
 	static void SetSlugifySeparator(CString val);
+
+	static BOOL m_supportAllTypes;
+	static BOOL GetSupportAllTypes();
+	static void SetSupportAllTypes(BOOL val);
 };
 
 // global for easy access and for initialization of fast access variables

--- a/OptionsTypes.cpp
+++ b/OptionsTypes.cpp
@@ -95,6 +95,7 @@ BOOL COptionsTypes::OnInitDialog()
 			m_List.AddString(_T("CF_HDROP"));
 			m_List.AddString(_T("CF_DIB"));
 			m_List.AddString(GetFormatName(GetFormatID(_T("HTML Format"))));
+			m_List.AddString(GetFormatName(GetFormatID(_T("PNG"))));
 		}
 
 		while(q.eof() == false)

--- a/ProcessPaste.cpp
+++ b/ProcessPaste.cpp
@@ -29,48 +29,45 @@ BOOL CProcessPaste::DoPaste()
 	try
 	{
 		m_pOle->m_pasteOptions = m_pasteOptions;
-
-		if (m_pOle->DoImmediateRender())
+		if (!m_pOle->DoImmediateRender())
 		{
-			// MarkAsPasted() must be done first since it makes use of
-			//  m_pOle->m_ClipIDs and m_pOle is inaccessible after
-			//  SetClipboard is called.
-			MarkAsPasted(m_pasteOptions.m_updateClipOrder);
-
-			// Ignore the clipboard change that we will cause IF:
-			// 1) we are pasting a single element, since the element is already
-			//    in the db and its lDate was updated by MarkAsPas???ted().
-			// OR
-			// 2) we are pasting multiple, but g_Opt.m_bSaveMultiPaste is false
-			if (GetClipIDs().GetSize() == 1 || !g_Opt.m_bSaveMultiPaste)
-			{
-				m_pOle->CacheGlobalData(theApp.m_cfIgnoreClipboard, NewGlobalP("Ignore", sizeof("Ignore")));
-			}
-			else
-			{
-				m_pOle->CacheGlobalData(theApp.m_cfDelaySavingData, NewGlobalP("Delay", sizeof("Delay")));
-			}
-
-			m_pOle->SetClipboard(); // m_pOle is now managed by the OLE clipboard
-
-			// The Clipboard now owns the allocated memory
-			// and will delete this data object
-			// when new data is put on the Clipboard
-			m_pOle = NULL; // m_pOle should not be accessed past this point
-
-			if (m_bSendPaste)
-			{
-				Log(_T("Sending Paste to active window"));
-				theApp.m_activeWnd.SendPaste(m_bActivateTarget);
-			}
-			else if (m_bActivateTarget)
-			{
-				Log(_T("Activating active window"));
-				theApp.m_activeWnd.ActivateTarget();
-			}
-
-			ret = TRUE;
+			return ret;
 		}
+
+		// MarkAsPasted() must be done first since it makes use of
+		//  m_pOle->m_ClipIDs and m_pOle is inaccessible after
+		//  SetClipboard is called.
+		MarkAsPasted(m_pasteOptions.m_updateClipOrder);
+
+		// Ignore the clipboard change that we will cause IF:
+		// 1) we are pasting a single element, since the element is already
+		//    in the db and its lDate was updated by MarkAsPasted().
+		// OR
+		// 2) we are pasting multiple, but g_Opt.m_bSaveMultiPaste is false
+		if (GetClipIDs().GetSize() == 1 || !g_Opt.m_bSaveMultiPaste)
+		{
+			m_pOle->CacheGlobalData(theApp.m_cfIgnoreClipboard, NewGlobalP("Ignore", sizeof("Ignore")));
+		}
+		else
+		{
+			m_pOle->CacheGlobalData(theApp.m_cfDelaySavingData, NewGlobalP("Delay", sizeof("Delay")));
+		}
+
+		m_pOle->SetClipboard(); // m_pOle is now managed by the OLE clipboard
+
+		if (m_bSendPaste)
+		{
+			Log(_T("Sending Paste to active window"));
+			theApp.m_activeWnd.SendPaste(m_bActivateTarget);
+		}
+		else if (m_bActivateTarget)
+		{
+			Log(_T("Activating active window"));
+			theApp.m_activeWnd.ActivateTarget();
+		}
+
+		ret = TRUE;
+	
 	}
 	catch (CException *ex)
 	{

--- a/QPasteWnd.cpp
+++ b/QPasteWnd.cpp
@@ -5184,38 +5184,37 @@ bool CQPasteWnd::DoExportToBitMapFile()
 				png = toSave.m_Formats.FindFormat(theApp.m_PNG_Format);
 			}
 
-			if (bitmap != NULL ||
-				png != NULL)
-			{
-				CString savePath = startingFilePath;
-				if (IDs.GetCount() > 1 ||
-					FileExists(startingFilePath))
-				{
-					savePath = _T("");
+			if (bitmap == NULL && png == NULL)
+				continue;
 
-					for (int y = lastFileCheckId; y < 1000000; y++)
+			CString savePath = startingFilePath;
+			if (IDs.GetCount() > 1 ||
+				FileExists(startingFilePath))
+			{
+				savePath = _T("");
+
+				for (int y = lastFileCheckId; y < 1000000; y++)
+				{
+					CString testFilePath;
+					testFilePath.Format(_T("%s%s_%d.%s"), csPath, csFileName, y, csExt);
+					if (FileExists(testFilePath) == FALSE)
 					{
-						CString testFilePath;
-						testFilePath.Format(_T("%s%s_%d.%s"), csPath, csFileName, y, csExt);
-						if (FileExists(testFilePath) == FALSE)
-						{
-							savePath = testFilePath;
-							lastFileCheckId = y+1;
-							break;
-						}
+						savePath = testFilePath;
+						lastFileCheckId = y+1;
+						break;
 					}
 				}
+			}
 
-				if (savePath != _T(""))
-				{
-					toSave.WriteImageToFile(savePath);
+			if (savePath != _T(""))
+			{
+				toSave.WriteImageToFile(savePath);
 
-					ret = true;
-				}
-				else
-				{
-					Log(StrF(_T("Failed to find a valid file name for starting path: %s"), startingFilePath));
-				}
+				ret = true;
+			}
+			else
+			{
+				Log(StrF(_T("Failed to find a valid file name for starting path: %s"), startingFilePath));
 			}
 		}
 	}

--- a/SendKeys.cpp
+++ b/SendKeys.cpp
@@ -394,9 +394,10 @@ WORD CSendKeys::StringToVKey(LPCTSTR KeyString, int &idx)
 // If we are in a modifier group this function does nothing
 void CSendKeys::PopUpShiftKeys()
 {
-  if (!m_bUsingParens)
-  {
-    if (m_bShiftDown)
+  if (m_bUsingParens)
+		return;
+
+  if (m_bShiftDown)
 	{
       SendKeyUp(VK_SHIFT);
 	}
@@ -429,8 +430,7 @@ void CSendKeys::PopUpShiftKeys()
       SendKeyUp(VK_LWIN);
 	}
 
-    m_bWinDown = m_bShiftDown = m_bLShiftDown = m_bRShiftDown = m_bControlDown = m_bLControlDown = m_bRControlDown = m_bAltDown = false;
-  }
+	m_bWinDown = m_bShiftDown = m_bLShiftDown = m_bRShiftDown = m_bControlDown = m_bLControlDown = m_bRControlDown = m_bAltDown = false;
 }
 
 // Sends a key string
@@ -582,27 +582,25 @@ bool CSendKeys::SendKeys(LPCTSTR KeysString, bool Wait)
         }
 
         // A valid key to send?
-		if (MKey != INVALIDKEY)
-		{
-			if (MKey == VK_LCONTROL ||
-				MKey == VK_RCONTROL)
-			{
-				m_bLControlDown = (MKey == VK_LCONTROL);
-				m_bRControlDown = (MKey == VK_RCONTROL);
-				SendKeyDown(MKey, 1, false);
-			}
-			else if (MKey == VK_LSHIFT ||
-					 MKey == VK_RSHIFT)
-			{
-				m_bLShiftDown = (MKey == VK_LSHIFT);
-				m_bRShiftDown = (MKey == VK_RSHIFT);
-				SendKeyDown(MKey, 1, false);
-			}
-			else
-			{		
-				SendKey(MKey, NumTimes, true);	
-				PopUpShiftKeys();
-			}
+        if (MKey != INVALIDKEY)
+        {
+          if (MKey == VK_LCONTROL || MKey == VK_RCONTROL)
+          {
+            m_bLControlDown = (MKey == VK_LCONTROL);
+            m_bRControlDown = (MKey == VK_RCONTROL);
+            SendKeyDown(MKey, 1, false);
+          }
+          else if (MKey == VK_LSHIFT || MKey == VK_RSHIFT)
+          {
+            m_bLShiftDown = (MKey == VK_LSHIFT);
+            m_bRShiftDown = (MKey == VK_RSHIFT);
+            SendKeyDown(MKey, 1, false);
+          }
+          else
+          {
+            SendKey(MKey, NumTimes, true);	
+            PopUpShiftKeys();
+          }
         }
       }
       break;


### PR DESCRIPTION
for solving #584 added some options.
1.  support PNG format as default.
  - Most programs these days support PNG natively.
  - Moreover if Ditto ignored PNG, CF_DIB is used that has many problems (Windows makes it as no alpha channel and many programs doesn't want to use it)
2. add support all types advanced option.
  - User might want Ditto to keep all data about clipboard
  - Currently, users have to add the type every time after recognizing the missing item.
  - Because it is experimental and it will ignore supported type list in main option confusedly, default is false.
  - ~~About GetAvailableTypes functions, there is re-check part after get available format using GetNextFormat.~~
  - ~~Because GetNextFormat has a bug that not return some of formats (especially CF_DIB), it will re-check to cover include at least the standard formats. [Ref](https://flylib.com/books/en/4.348.1.87/1/)~~
3. in WriteImageToFile use PNG first.
  - PNG might be closer to original source. (CF_DIB is most likely lost information.)

refactoring things
1. add Image helper to assemble image process.
2. rename variables that makes confuse.
3. code diet to enhance readability.
4. remove special action about Edge. (currently Edge use chromium and it's process name is no more MicrosoftEdge.exe)

Happy new year~