### PR TITLE
fix FocusCaret to get caret in Chrome

### DIFF
--- a/ExternalWindowTracker.cpp
+++ b/ExternalWindowTracker.cpp
@@ -432,51 +432,79 @@ CPoint ExternalWindowTracker::FocusCaret()
 {
 	CPoint pt(-1, -1);
 
-	if(m_activeWnd)
+	if(!m_activeWnd || !m_focusWnd)
+		return pt;
+
+	GUITHREADINFO guiThreadInfo;
+	guiThreadInfo.cbSize = sizeof(GUITHREADINFO);
+	DWORD OtherThreadID = GetWindowThreadProcessId(m_activeWnd, NULL);
+	if(GetGUIThreadInfo(OtherThreadID, &guiThreadInfo))
 	{
-		GUITHREADINFO guiThreadInfo;
-		guiThreadInfo.cbSize = sizeof(GUITHREADINFO);
-		DWORD OtherThreadID = GetWindowThreadProcessId(m_activeWnd, NULL);
-		if(GetGUIThreadInfo(OtherThreadID, &guiThreadInfo))
+		CRect rc(guiThreadInfo.rcCaret);
+		if(rc.IsRectEmpty() == FALSE)
 		{
-			CRect rc(guiThreadInfo.rcCaret);
-			if(rc.IsRectEmpty() == FALSE)
-			{
-				pt = rc.BottomRight();
-				::ClientToScreen(m_focusWnd, &pt);
-			}
-		}
-
-		if(pt.x == -1 || pt.y == -1)
-		{
-			if(m_focusWnd != NULL &&
-				m_activeWnd != NULL &&
-				AttachThreadInput(GetWindowThreadProcessId(m_activeWnd, NULL), GetCurrentThreadId(), TRUE))
-			{
-				BOOL ret = GetCaretPos(&pt);
-				if(ret && (pt.x != 0 && pt.y != 0))
-				{
-					::ClientToScreen(m_focusWnd, &pt);
-					if (pt.y != 0 && pt.x != 0)
-					{
-						pt.y += 20;
-					}
-					else
-					{
-						pt.x = -1;
-						pt.y = -1;
-					}
-				}
-				else
-				{
-					pt.x = -1;
-					pt.y = -1;
-				}
-
-				AttachThreadInput(GetWindowThreadProcessId(m_activeWnd, NULL), GetCurrentThreadId(), FALSE);
-			}
+			pt = rc.BottomRight();
+			::ClientToScreen(m_focusWnd, &pt);
 		}
 	}
+	if(pt.x != -1 && pt.y != -1)
+		return pt;
+
+	DWORD currentThreadId = GetCurrentThreadId();
+	if(AttachThreadInput(OtherThreadID, currentThreadId, TRUE))
+	{
+		BOOL ok = GetCaretPos(&pt);
+		if(ok && (pt.x != 0 && pt.y != 0))
+		{
+			::ClientToScreen(m_focusWnd, &pt);
+			if (pt.y != 0 && pt.x != 0)
+			{
+				// calculate offset of caret by GetCaretPos
+				pt.y += 20;
+			}
+			else
+			{
+				pt.x = -1;
+				pt.y = -1;
+			}
+		}
+		else
+		{
+			pt.x = -1;
+			pt.y = -1;
+		}
+
+		AttachThreadInput(OtherThreadID, currentThreadId, FALSE);
+	}
+	if(pt.x != -1 && pt.y != -1)
+		return pt;
+
+	// trying to get caret for some hard applications like Chrome.
+	HMODULE hOleacc = LoadLibrary(_T("oleacc.dll"));
+	if (!hOleacc)
+		return pt;
+
+	typedef HRESULT(__stdcall *AccessibleObjectFromWindow)(_In_ HWND hwnd, _In_ DWORD dwId, _In_ REFIID riid, _Outptr_ void** ppvObject);
+	AccessibleObjectFromWindow getObject = (AccessibleObjectFromWindow)GetProcAddress(hOleacc, "AccessibleObjectFromWindow");
+	if (!getObject)
+		return pt;
+
+	IAccessible* pIAccessible = NULL;
+	HRESULT hr = getObject(m_activeWnd, OBJID_CARET, __uuidof(IAccessible), (void**)&pIAccessible);
+	if(hr != S_OK)
+		return pt;
+
+	long left = 0, top = 0, width = 0, height = 0;
+	VARIANT varCaret;
+	varCaret.vt = VT_I4;
+	varCaret.lVal = CHILDID_SELF;
+	hr = pIAccessible->accLocation(&left, &top, &width, &height, varCaret);
+	pIAccessible->Release();
+	if (hr != S_OK)
+		return pt;
+
+	// calculate offset of caret by Accessible 
+	pt.SetPoint(left + width, top + 20);
 
 	return pt;
 }


### PR DESCRIPTION
To solve #375 I added a logic to find caret position from Chrome via oleacc.dll.
Now Ditto can find caret from more variety application like VS, VS Code, etc.
But like as the [reference](https://www.reddit.com/r/AutoHotkey/comments/ysuawq/get_the_caret_location_in_any_program/) that  @u-Sir gave, It is not cover UWP applications yet.
So, this is just first solution of the issue (because i think Chrome is more important than any others) and I will decide whether to add a logic to support UWP apps after.