### PR TITLE
Fix clipboard data handling issue

### DIFF
--- a/src/ClipboardSaveRestore.cpp
+++ b/src/ClipboardSaveRestore.cpp
@@ -26,23 +26,26 @@ bool CClipboardSaveRestore::Save(BOOL textOnly)
 			if(textOnly == false || (nFormat == CF_TEXT || nFormat == CF_UNICODETEXT || nFormat == CF_HDROP))
 			{
 				HGLOBAL hGlobal = ::GetClipboardData(nFormat);
-				LPVOID pvData = GlobalLock(hGlobal);
-				if(pvData)
+				if(hGlobal && ::GlobalSize(hGlobal) > 0) // Ensure clipboard data is valid
 				{
-					INT_PTR size = GlobalSize(hGlobal);
-					if(size > 0)
+					LPVOID pvData = GlobalLock(hGlobal);
+					if(pvData)
 					{
-						//Copy the data locally
-						cf.m_hgData = NewGlobalP(pvData, size);	
-						cf.m_cfType = nFormat;
+						INT_PTR size = GlobalSize(hGlobal);
+						if(size > 0)
+						{
+							//Copy the data locally
+							cf.m_hgData = NewGlobalP(pvData, size);	
+							cf.m_cfType = nFormat;
 
-						m_Clipboard.Add(cf);
+							m_Clipboard.Add(cf);
 
-						//m_Clipboard owns the data now
-						cf.m_hgData = NULL;
+							//m_Clipboard owns the data now
+							cf.m_hgData = NULL;
+						}
+
+						GlobalUnlock(hGlobal);
 					}
-
-					GlobalUnlock(hGlobal);
 				}
 			}
 			nFormat = EnumClipboardFormats(nFormat);
@@ -69,7 +72,7 @@ bool CClipboardSaveRestore::Restore()
 		for(int nPos = 0; nPos < size; nPos++)
 		{
 			CClipFormat *pCF = &m_Clipboard.ElementAt(nPos);
-			if(pCF && pCF->m_hgData)
+			if(pCF && pCF->m_hgData && ::GlobalSize(pCF->m_hgData) > 0) // Ensure clipboard data is valid
 			{
 				::SetClipboardData(pCF->m_cfType, pCF->m_hgData);
 				pCF->m_hgData = NULL;//clipboard now owns the data
@@ -107,7 +110,7 @@ bool CClipboardSaveRestore::RestoreTextOnly()
 		for(int pos = 0; pos < size; pos++)
 		{
 			CClipFormat *pCF = &m_Clipboard.ElementAt(pos);
-			if(pCF && pCF->m_hgData)
+			if(pCF && pCF->m_hgData && ::GlobalSize(pCF->m_hgData) > 0) // Ensure clipboard data is valid
 			{
 				if(pCF->m_cfType == CF_TEXT || pCF->m_cfType == CF_UNICODETEXT)
 				{
@@ -135,7 +138,7 @@ bool CClipboardSaveRestore::RestoreTextOnly()
 		{
 			CString hDropString;
 			CClipFormat *pCF = &m_Clipboard.ElementAt(hDropIndex);
-			if(pCF && pCF->m_hgData)
+			if(pCF && pCF->m_hgData && ::GlobalSize(pCF->m_hgData) > 0) // Ensure clipboard data is valid
 			{
 				HDROP drop = (HDROP)GlobalLock(pCF->m_hgData);
 				int nNumFiles = DragQueryFile(drop, -1, NULL, 0);

--- a/src/ClipboardViewer.cpp
+++ b/src/ClipboardViewer.cpp
@@ -294,7 +294,7 @@ void CClipboardViewer::OnDrawClipboard()
 bool CClipboardViewer::ValidActiveWnd()
 {
 	m_activeWindow = _T("");
-	m_activeWindowTitle = _T("";)
+	m_activeWindowTitle = _T("");
 
 	HWND owner = ::GetClipboardOwner();
 	if (owner != NULL)


### PR DESCRIPTION
Fixes #796

Fix clipboard data handling to prevent symbol insertion instead of copying links.

* **src/ClipboardViewer.cpp**
  - Correct the initialization of `m_activeWindowTitle` in `ValidActiveWnd` method.
  - Add a newline at the end of the file.

* **src/ClipboardSaveRestore.cpp**
  - Add checks to ensure clipboard data is valid before processing in `Save` and `Restore` methods.
  - Add checks to ensure clipboard data is valid before processing in multiple locations within the `Restore` method.
  - Add a newline at the end of the file.
