### PR TITLE
Fix color match + refactor QListCtl, tweak theme, allow lowercase RGB in  Theme.cpp

### DIFF
--- a/Debug/Themes/Monolight.xml
+++ b/Debug/Themes/Monolight.xml
@@ -1,50 +1,51 @@
 <Ditto_Theme_File Version="3" Author="dcog989" Notes="Monolight">
 
-	<CaptionLeft>RGB(107,114,125)</CaptionLeft>
-	<CaptionRight>RGB(144,151,163)</CaptionRight>
+    <CaptionLeft>RGB(107,114,125)</CaptionLeft>
+    <CaptionRight>RGB(144,151,163)</CaptionRight>
 
-	<CaptionLeftTopMost>RGB(107,114,125)</CaptionLeftTopMost>
-	<CaptionRightTopMost>RGB(174,177,181)</CaptionRightTopMost>
+    <CaptionLeftTopMost>RGB(107,114,125)</CaptionLeftTopMost>
+    <CaptionRightTopMost>RGB(174,177,181)</CaptionRightTopMost>
 
-	<CaptionLeftNotConnected>RGB(74,40,40)</CaptionLeftNotConnected>
-	<CaptionRightNotConnected>RGB(209,180,180)</CaptionRightNotConnected>
+    <CaptionLeftNotConnected>RGB(74,40,40)</CaptionLeftNotConnected>
+    <CaptionRightNotConnected>RGB(209,180,180)</CaptionRightNotConnected>
 
-	<CaptionTextColor>RGB(191,196,203)</CaptionTextColor>
+    <CaptionTextColor>RGB(191,196,203)</CaptionTextColor>
 
-	<ListBoxOddRowsBG>RGB(227,232,240)</ListBoxOddRowsBG>
-	<ListBoxEvenRowsBG>RGB(211,218,227)</ListBoxEvenRowsBG>
+    <ListBoxOddRowsBG>RGB(227,232,240)</ListBoxOddRowsBG>
+    <ListBoxEvenRowsBG>RGB(211,218,227)</ListBoxEvenRowsBG>
 
-	<ListBoxOddRowsText>RGB(50,61,73)</ListBoxOddRowsText>
-	<ListBoxEvenRowsText>RGB(50,61,73)</ListBoxEvenRowsText>
+    <ListBoxOddRowsText>RGB(50,61,73)</ListBoxOddRowsText>
+    <ListBoxEvenRowsText>RGB(50,61,73)</ListBoxEvenRowsText>
 
-	<ListBoxSelectedBG>RGB(245,239,203)</ListBoxSelectedBG>
-	<ListBoxSelectedNoFocusBG>RGB(237,236,226)</ListBoxSelectedNoFocusBG>
+    <ListBoxSelectedBG>RGB(245,239,203)</ListBoxSelectedBG>
+    <ListBoxSelectedNoFocusBG>RGB(237,236,226)</ListBoxSelectedNoFocusBG>
 
-	<ListBoxSelectedText>RGB(44,47,50)</ListBoxSelectedText>
-	<ListBoxSelectedNoFocusText>RGB(44,47,50)</ListBoxSelectedNoFocusText>
+    <ListBoxSelectedText>RGB(44,47,50)</ListBoxSelectedText>
+    <ListBoxSelectedNoFocusText>RGB(44,47,50)</ListBoxSelectedNoFocusText>
 
-	<ClipPastedColor>RGB(144,151,163)</ClipPastedColor>
+    <ClipPastedColor>RGB(144,151,163)</ClipPastedColor>
 
-	<MainWindowBG>RGB(191,196,203)</MainWindowBG>
+    <MainWindowBG>RGB(191,196,203)</MainWindowBG>
 
-	<SearchTextBoxFocusBG>RGB(215,219,226)</SearchTextBoxFocusBG>
-	<SearchTextBoxFocusText>RGB(44,47,50)</SearchTextBoxFocusText>
+    <SearchTextBoxFocusBG>RGB(215,219,226)</SearchTextBoxFocusBG>
+    <SearchTextBoxFocusText>RGB(44,47,50)</SearchTextBoxFocusText>
 
-	<SearchTextBoxFocusBorder>RGB(77,82,90)</SearchTextBoxFocusBorder>
-	<SearchTextHighlight>RGB(74,40,40)</SearchTextHighlight>
+    <SearchTextBoxFocusBorder>RGB(77,82,90)</SearchTextBoxFocusBorder>
+    <SearchTextHighlight>RGB(74,40,40)</SearchTextHighlight>
 
-	<Border>RGB(144,151,163)</Border>
+    <Border>RGB(144,151,163)</Border>
 
-	<BorderTopMost>RGB(77,82,90)</BorderTopMost>
-	<BorderNotConnected>RGB(44,47,50)</BorderNotConnected>
+    <BorderTopMost>RGB(77,82,90)</BorderTopMost>
+    <BorderNotConnected>RGB(44,47,50)</BorderNotConnected>
 
-	<GroupTreeBG>RGB(241,238,225)</GroupTreeBG>
-	<GroupTreeText>RGB(70,67,55)</GroupTreeText>
+    <GroupTreeBG>RGB(241,238,225)</GroupTreeBG>
+    <GroupTreeText>RGB(70,67,55)</GroupTreeText>
 
-	<CaptionSize>26</CaptionSize>
-	<CaptionFontSize>13</CaptionFontSize>
+    <CaptionSize>26</CaptionSize>
+    <CaptionFontSize>13</CaptionFontSize>
 
-	<DescriptionWindowBG>RGB(190,193,197)</DescriptionWindowBG>
-	<DescriptionWindowText>RGB(44,47,50)</DescriptionWindowText>
+    <DescriptionWindowBG>RGB(190,193,197)</DescriptionWindowBG>
+    <DescriptionWindowText>RGB(44,47,50)</DescriptionWindowText>
 
 </Ditto_Theme_File>
+

--- a/Debug/Themes/Monolight.xml
+++ b/Debug/Themes/Monolight.xml
@@ -1,50 +1,50 @@
 <Ditto_Theme_File Version="3" Author="dcog989" Notes="Monolight">
 
-  <CaptionLeft>RGB(107,114,125)</CaptionLeft>
-  <CaptionRight>RGB(144,151,163)</CaptionRight>
+	<CaptionLeft>RGB(107,114,125)</CaptionLeft>
+	<CaptionRight>RGB(144,151,163)</CaptionRight>
 
-  <CaptionLeftTopMost>RGB(107,114,125)</CaptionLeftTopMost>
-  <CaptionRightTopMost>RGB(174,177,181)</CaptionRightTopMost>
+	<CaptionLeftTopMost>RGB(107,114,125)</CaptionLeftTopMost>
+	<CaptionRightTopMost>RGB(174,177,181)</CaptionRightTopMost>
 
-  <CaptionLeftNotConnected>RGB(74,40,40)</CaptionLeftNotConnected>
-  <CaptionRightNotConnected>RGB(209,180,180)</CaptionRightNotConnected>
+	<CaptionLeftNotConnected>RGB(74,40,40)</CaptionLeftNotConnected>
+	<CaptionRightNotConnected>RGB(209,180,180)</CaptionRightNotConnected>
 
-  <CaptionTextColor>RGB(191,196,203)</CaptionTextColor>
+	<CaptionTextColor>RGB(191,196,203)</CaptionTextColor>
 
-  <ListBoxOddRowsBG>RGB(227,232,240)</ListBoxOddRowsBG>
-  <ListBoxEvenRowsBG>RGB(211,218,227)</ListBoxEvenRowsBG>
+	<ListBoxOddRowsBG>RGB(227,232,240)</ListBoxOddRowsBG>
+	<ListBoxEvenRowsBG>RGB(211,218,227)</ListBoxEvenRowsBG>
 
-  <ListBoxOddRowsText>RGB(44,47,50)</ListBoxOddRowsText>
-  <ListBoxEvenRowsText>RGB(44,47,50)</ListBoxEvenRowsText>
+	<ListBoxOddRowsText>RGB(50,61,73)</ListBoxOddRowsText>
+	<ListBoxEvenRowsText>RGB(50,61,73)</ListBoxEvenRowsText>
 
-  <ListBoxSelectedBG>RGB(245,239,203)</ListBoxSelectedBG>
-  <ListBoxSelectedNoFocusBG>RGB(237,236,226)</ListBoxSelectedNoFocusBG>
+	<ListBoxSelectedBG>RGB(245,239,203)</ListBoxSelectedBG>
+	<ListBoxSelectedNoFocusBG>RGB(237,236,226)</ListBoxSelectedNoFocusBG>
 
-  <ListBoxSelectedText>RGB(44,47,50)</ListBoxSelectedText>
-  <ListBoxSelectedNoFocusText>RGB(44,47,50)</ListBoxSelectedNoFocusText>
+	<ListBoxSelectedText>RGB(44,47,50)</ListBoxSelectedText>
+	<ListBoxSelectedNoFocusText>RGB(44,47,50)</ListBoxSelectedNoFocusText>
 
-  <ClipPastedColor>RGB(144,151,163)</ClipPastedColor>
+	<ClipPastedColor>RGB(144,151,163)</ClipPastedColor>
 
-  <MainWindowBG>RGB(191,196,203)</MainWindowBG>
+	<MainWindowBG>RGB(191,196,203)</MainWindowBG>
 
-  <SearchTextBoxFocusBG>RGB(215,219,226)</SearchTextBoxFocusBG>
-  <SearchTextBoxFocusText>RGB(44,47,50)</SearchTextBoxFocusText>
+	<SearchTextBoxFocusBG>RGB(215,219,226)</SearchTextBoxFocusBG>
+	<SearchTextBoxFocusText>RGB(44,47,50)</SearchTextBoxFocusText>
 
-  <SearchTextBoxFocusBorder>RGB(77,82,90)</SearchTextBoxFocusBorder>
-  <SearchTextHighlight>RGB(74,40,40)</SearchTextHighlight>
+	<SearchTextBoxFocusBorder>RGB(77,82,90)</SearchTextBoxFocusBorder>
+	<SearchTextHighlight>RGB(74,40,40)</SearchTextHighlight>
 
-  <Border>RGB(144,151,163)</Border>
+	<Border>RGB(144,151,163)</Border>
 
-  <BorderTopMost>RGB(77,82,90)</BorderTopMost>
-  <BorderNotConnected>RGB(44,47,50)</BorderNotConnected>
+	<BorderTopMost>RGB(77,82,90)</BorderTopMost>
+	<BorderNotConnected>RGB(44,47,50)</BorderNotConnected>
 
-  <GroupTreeBG>RGB(241,238,225)</GroupTreeBG>
-  <GroupTreeText>RGB(70,67,55)</GroupTreeText>
+	<GroupTreeBG>RGB(241,238,225)</GroupTreeBG>
+	<GroupTreeText>RGB(70,67,55)</GroupTreeText>
 
-  <CaptionSize>26</CaptionSize>
-  <CaptionFontSize>13</CaptionFontSize>
+	<CaptionSize>26</CaptionSize>
+	<CaptionFontSize>13</CaptionFontSize>
 
-  <DescriptionWindowBG>RGB(190,193,197)</DescriptionWindowBG>
-  <DescriptionWindowText>RGB(44,47,50)</DescriptionWindowText>
+	<DescriptionWindowBG>RGB(190,193,197)</DescriptionWindowBG>
+	<DescriptionWindowText>RGB(44,47,50)</DescriptionWindowText>
 
 </Ditto_Theme_File>

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -8,283 +8,294 @@
 
 CTheme::CTheme(void)
 {
-	m_lFileVersion = 0;
-	m_LastWriteTime = 0;
-	m_lastTheme = _T("");
+        m_lFileVersion = 0;
+        m_LastWriteTime = 0;
+        m_lastTheme = _T("");
 
-	LoadDefaults();
+        LoadDefaults();
 }
 
 CTheme::~CTheme(void)
 {
 }
 
-
 void CTheme::LoadDefaults()
 {
-	m_CaptionLeft = RGB(255, 255, 255);
-	m_CaptionRight = RGB(204, 204, 204);
+        m_CaptionLeft = RGB(255, 255, 255);
+        m_CaptionRight = RGB(204, 204, 204);
 
-	m_Border = RGB(204, 204, 204);
-	m_BorderTopMost = RGB(204, 204, 204);
-	m_BorderNotConnected = RGB(204, 204, 204);
+        m_Border = RGB(204, 204, 204);
+        m_BorderTopMost = RGB(204, 204, 204);
+        m_BorderNotConnected = RGB(204, 204, 204);
 
-	m_CaptionLeftTopMost = RGB(255, 255, 255);
-	m_CaptionRightTopMost = RGB(204, 204, 204);
-	
-	m_CaptionLeftNotConnected = RGB(255, 255, 255);
-	m_CaptionRightNotConnected = RGB(255, 255, 0);
+        m_CaptionLeftTopMost = RGB(255, 255, 255);
+        m_CaptionRightTopMost = RGB(204, 204, 204);
 
-	m_CaptionTextColor = RGB(191, 191, 191);
-	m_ListBoxOddRowsBG = RGB(255, 255, 255);
-	m_ListBoxEvenRowsBG = RGB(243, 243, 243);
-	m_ListBoxOddRowsText = RGB(0, 0, 0);
-	m_ListBoxEvenRowsText = RGB(0, 0, 0);
-	m_ListBoxSelectedBG = RGB(204, 204, 204);
-	m_ListBoxSelectedNoFocusBG = RGB(204, 204, 204);
-	m_ListBoxSelectedText = RGB(0, 0, 0);
-	m_ListBoxSelectedNoFocusText = RGB(0, 0, 0);
-	m_clipPastedColor = RGB(0, 255, 0);
-	m_listSmallQuickPasteIndexColor = RGB(180, 180, 180);
-	m_mainWindowBG = RGB(240, 240, 240);
-	m_searchTextBoxFocusBG = RGB(255, 255, 255);
-	m_searchTextBoxFocusText = RGB(0, 0, 0);
-	m_searchTextBoxFocusBorder = RGB(255, 255, 255);
-	m_searchTextHighlight = RGB(255, 0, 0);
+        m_CaptionLeftNotConnected = RGB(255, 255, 255);
+        m_CaptionRightNotConnected = RGB(255, 255, 0);
 
-	m_groupTreeBG = RGB(240, 240, 240);
-	m_groupTreeText = RGB(127, 127, 127);
+        m_CaptionTextColor = RGB(191, 191, 191);
+        m_ListBoxOddRowsBG = RGB(255, 255, 255);
+        m_ListBoxEvenRowsBG = RGB(243, 243, 243);
+        m_ListBoxOddRowsText = RGB(0, 0, 0);
+        m_ListBoxEvenRowsText = RGB(0, 0, 0);
+        m_ListBoxSelectedBG = RGB(204, 204, 204);
+        m_ListBoxSelectedNoFocusBG = RGB(204, 204, 204);
+        m_ListBoxSelectedText = RGB(0, 0, 0);
+        m_ListBoxSelectedNoFocusText = RGB(0, 0, 0);
+        m_clipPastedColor = RGB(0, 255, 0);
+        m_listSmallQuickPasteIndexColor = RGB(180, 180, 180);
+        m_mainWindowBG = RGB(240, 240, 240);
+        m_searchTextBoxFocusBG = RGB(255, 255, 255);
+        m_searchTextBoxFocusText = RGB(0, 0, 0);
+        m_searchTextBoxFocusBorder = RGB(255, 255, 255);
+        m_searchTextHighlight = RGB(255, 0, 0);
 
-	m_descriptionWindowBG = RGB(240, 240, 240);// GetSysColor(COLOR_INFOBK);//RGB(240, 240, 240);//
-	/*int r = GetRValue(m_descriptionWindowBG);
-	int g = GetGValue(m_descriptionWindowBG);
-	int b = GetBValue(m_descriptionWindowBG);*/
+        m_groupTreeBG = RGB(240, 240, 240);
+        m_groupTreeText = RGB(127, 127, 127);
 
-	m_descriptionWindowText = RGB(0, 0, 0);
+        m_descriptionWindowBG = RGB(240, 240, 240);// GetSysColor(COLOR_INFOBK);//RGB(240, 240, 240);//
+        /*int r = GetRValue(m_descriptionWindowBG);
+        int g = GetGValue(m_descriptionWindowBG);
+        int b = GetBValue(m_descriptionWindowBG);*/
 
-	m_captionSize = 25;
-	m_captionFontSize = 19;
+        m_descriptionWindowText = RGB(0, 0, 0);
+
+        m_captionSize = 25;
+        m_captionFontSize = 19;
 }
 
 bool CTheme::Load(CString csTheme, bool bHeaderOnly, bool bCheckLastWriteTime)
 {
-	bool followWindows10Theme = false;
-	if (csTheme.IsEmpty())
-	{
-		followWindows10Theme = true;
+        bool followWindows10Theme = false;
+        if (csTheme.IsEmpty())
+        {
+                followWindows10Theme = true;
 
-		if (DarkAppWindows10Setting())
-		{
-			csTheme = _T("DarkerDitto");
-			Log(_T("Loading theme based on windows setting of dark mode for apps"));			
-		}
-	}
+                if (DarkAppWindows10Setting())
+                {
+                        csTheme = _T("DarkerDitto");
+                        Log(_T("Loading theme based on windows setting of dark mode for apps"));
+                }
+        }
 
-	if (csTheme.IsEmpty() || csTheme == _T("Ditto") || csTheme == _T("(Default)") || csTheme == _T("(Ditto)"))
-	{
-		LoadDefaults();
+        if (csTheme.IsEmpty() || csTheme == _T("Ditto") || csTheme == _T("(Default)") || csTheme == _T("(Ditto)"))
+        {
+                LoadDefaults();
 
-		if (followWindows10Theme)
-		{
-			LoadWindowsAccentColor();
-		}
+                if (followWindows10Theme)
+                {
+                        LoadWindowsAccentColor();
+                }
 
-		m_LastWriteTime = 0;
-		m_lastTheme = _T("");
+                m_LastWriteTime = 0;
+                m_lastTheme = _T("");
 
-		Log(_T("Loading default ditto values for themes"));
+                Log(_T("Loading default ditto values for themes"));
 
-		return false;
-	}
+                return false;
+        }
 
-	CString csPath = CGetSetOptions::GetPath(PATH_THEMES);
-	csPath += csTheme;
-	csPath += ".xml";
+        CString csPath = CGetSetOptions::GetPath(PATH_THEMES);
+        csPath += csTheme;
+        csPath += ".xml";
 
-	__int64 LastWrite = GetLastWriteTime(csPath);
+        __int64 LastWrite = GetLastWriteTime(csPath);
 
-	if(bCheckLastWriteTime)
-	{	
-		if(m_lastTheme == csTheme &&
-			LastWrite == m_LastWriteTime)
-		{
-			return true;
-		}
-	}
+        if (bCheckLastWriteTime)
+        {
+                if (m_lastTheme == csTheme &&
+                    LastWrite == m_LastWriteTime)
+                {
+                        return true;
+                }
+        }
 
-	LoadDefaults();
+        LoadDefaults();
 
-	m_LastWriteTime = LastWrite;
-	m_lastTheme = csTheme;
+        m_LastWriteTime = LastWrite;
+        m_lastTheme = csTheme;
 
-	Log(StrF(_T("Loading Theme %s"), csPath));
+        Log(StrF(_T("Loading Theme %s"), csPath));
 
-	TiXmlDocument doc;
-	if(!doc.LoadFile(csPath.GetBuffer()))
-	{
-		m_csLastError.Format(_T("Error loading Theme %s - reason = %s"), csPath, doc.ErrorDesc());
-		ASSERT(!m_csLastError);
-		Log(m_csLastError);
-		return false;
-	}
+        TiXmlDocument doc;
+        if (!doc.LoadFile(csPath.GetBuffer()))
+        {
+                m_csLastError.Format(_T("Error loading Theme %s - reason = %s"), csPath, doc.ErrorDesc());
+                ASSERT(!m_csLastError);
+                Log(m_csLastError);
+                return false;
+        }
 
-	TiXmlElement *ItemHeader = doc.FirstChildElement("Ditto_Theme_File");
-	if(!ItemHeader)
-	{
-		m_csLastError.Format(_T("Error finding the section Ditto_Theme_File"));
-		ASSERT(!m_csLastError);
-		Log(m_csLastError);
-		return false;
-	}
+        TiXmlElement *ItemHeader = doc.FirstChildElement("Ditto_Theme_File");
+        if (!ItemHeader)
+        {
+                m_csLastError.Format(_T("Error finding the section Ditto_Theme_File"));
+                ASSERT(!m_csLastError);
+                Log(m_csLastError);
+                return false;
+        }
 
-	CString csVersion = ItemHeader->Attribute("Version");
-	m_lFileVersion = ATOI(csVersion);
-	m_csAuthor = ItemHeader->Attribute("Author");
-	m_csNotes = ItemHeader->Attribute("Notes");
+        CString csVersion = ItemHeader->Attribute("Version");
+        m_lFileVersion = ATOI(csVersion);
+        m_csAuthor = ItemHeader->Attribute("Author");
+        m_csNotes = ItemHeader->Attribute("Notes");
 
-	if(bHeaderOnly)
-		return true;
+        if (bHeaderOnly)
+                return true;
 
+        LoadColor(ItemHeader, "CaptionLeft", m_CaptionLeft);
+        LoadColor(ItemHeader, "CaptionRight", m_CaptionRight);
+        LoadColor(ItemHeader, "CaptionLeftTopMost", m_CaptionLeftTopMost);
+        LoadColor(ItemHeader, "CaptionRightTopMost", m_CaptionRightTopMost);
+        LoadColor(ItemHeader, "CaptionLeftNotConnected", m_CaptionLeftNotConnected);
+        LoadColor(ItemHeader, "CaptionRightNotConnected", m_CaptionRightNotConnected);
+        LoadColor(ItemHeader, "CaptionTextColor", m_CaptionTextColor);
+        LoadColor(ItemHeader, "ListBoxOddRowsBG", m_ListBoxOddRowsBG);
+        LoadColor(ItemHeader, "ListBoxEvenRowsBG", m_ListBoxEvenRowsBG);
+        LoadColor(ItemHeader, "ListBoxOddRowsText", m_ListBoxOddRowsText);
+        LoadColor(ItemHeader, "ListBoxEvenRowsText", m_ListBoxEvenRowsText);
+        LoadColor(ItemHeader, "ListBoxSelectedBG", m_ListBoxSelectedBG);
+        LoadColor(ItemHeader, "ListBoxSelectedNoFocusBG", m_ListBoxSelectedNoFocusBG);
+        LoadColor(ItemHeader, "ListBoxSelectedText", m_ListBoxSelectedText);
+        LoadColor(ItemHeader, "ListBoxSelectedNoFocusText", m_ListBoxSelectedNoFocusText);
+        LoadColor(ItemHeader, "ClipPastedColor", m_clipPastedColor);
+        LoadColor(ItemHeader, "MainWindowBG", m_mainWindowBG);
+        LoadColor(ItemHeader, "SearchTextBoxFocusBG", m_searchTextBoxFocusBG);
+        LoadColor(ItemHeader, "SearchTextBoxFocusText", m_searchTextBoxFocusText);
+        LoadColor(ItemHeader, "SearchTextBoxFocusBorder", m_searchTextBoxFocusBorder);
+        LoadColor(ItemHeader, "SearchTextHighlight", m_searchTextHighlight);
 
-	LoadColor(ItemHeader, "CaptionLeft", m_CaptionLeft);
-	LoadColor(ItemHeader, "CaptionRight", m_CaptionRight);
-	LoadColor(ItemHeader, "CaptionLeftTopMost", m_CaptionLeftTopMost);
-	LoadColor(ItemHeader, "CaptionRightTopMost", m_CaptionRightTopMost);
-	LoadColor(ItemHeader, "CaptionLeftNotConnected", m_CaptionLeftNotConnected);
-	LoadColor(ItemHeader, "CaptionRightNotConnected", m_CaptionRightNotConnected);
-	LoadColor(ItemHeader, "CaptionTextColor", m_CaptionTextColor);
-	LoadColor(ItemHeader, "ListBoxOddRowsBG", m_ListBoxOddRowsBG);
-	LoadColor(ItemHeader, "ListBoxEvenRowsBG", m_ListBoxEvenRowsBG);
-	LoadColor(ItemHeader, "ListBoxOddRowsText", m_ListBoxOddRowsText);
-	LoadColor(ItemHeader, "ListBoxEvenRowsText", m_ListBoxEvenRowsText);
-	LoadColor(ItemHeader, "ListBoxSelectedBG", m_ListBoxSelectedBG);
-	LoadColor(ItemHeader, "ListBoxSelectedNoFocusBG", m_ListBoxSelectedNoFocusBG);
-	LoadColor(ItemHeader, "ListBoxSelectedText", m_ListBoxSelectedText);
-	LoadColor(ItemHeader, "ListBoxSelectedNoFocusText", m_ListBoxSelectedNoFocusText);
-	LoadColor(ItemHeader, "ClipPastedColor", m_clipPastedColor);
-	LoadColor(ItemHeader, "MainWindowBG", m_mainWindowBG);
-	LoadColor(ItemHeader, "SearchTextBoxFocusBG", m_searchTextBoxFocusBG);
-	LoadColor(ItemHeader, "SearchTextBoxFocusText", m_searchTextBoxFocusText);
-	LoadColor(ItemHeader, "SearchTextBoxFocusBorder", m_searchTextBoxFocusBorder);
-	LoadColor(ItemHeader, "SearchTextHighlight", m_searchTextHighlight);
+        LoadColor(ItemHeader, "Border", m_Border);
+        LoadColor(ItemHeader, "BorderTopMost", m_BorderTopMost);
+        LoadColor(ItemHeader, "BorderNotConnected", m_BorderNotConnected);
 
-	LoadColor(ItemHeader, "Border", m_Border);
-	LoadColor(ItemHeader, "BorderTopMost", m_BorderTopMost);
-	LoadColor(ItemHeader, "BorderNotConnected", m_BorderNotConnected);
+        LoadColor(ItemHeader, "GroupTreeBG", m_groupTreeBG);
+        LoadColor(ItemHeader, "GroupTreeText", m_groupTreeText);
 
-	LoadColor(ItemHeader, "GroupTreeBG", m_groupTreeBG);
-	LoadColor(ItemHeader, "GroupTreeText", m_groupTreeText);
-	
-	LoadInt(ItemHeader, "CaptionSize", m_captionSize);
-	LoadInt(ItemHeader, "CaptionFontSize", m_captionFontSize);
+        LoadInt(ItemHeader, "CaptionSize", m_captionSize);
+        LoadInt(ItemHeader, "CaptionFontSize", m_captionFontSize);
 
-	LoadColor(ItemHeader, "DescriptionWindowBG", m_descriptionWindowBG);
-	LoadColor(ItemHeader, "DescriptionWindowText", m_descriptionWindowText);
+        LoadColor(ItemHeader, "DescriptionWindowBG", m_descriptionWindowBG);
+        LoadColor(ItemHeader, "DescriptionWindowText", m_descriptionWindowText);
 
-	if (followWindows10Theme)
-	{
-		LoadWindowsAccentColor();
-	}
+        if (followWindows10Theme)
+        {
+                LoadWindowsAccentColor();
+        }
 
-	return true;
+        return true;
 }
 
 void CTheme::LoadWindowsAccentColor()
 {
-	DWORD accent = Windows10AccentColor();
-	if (accent != -1)
-	{
-		//windows seems to be bgr, convert to rgb
-		auto r = GetRValue(accent);
-		auto g = GetGValue(accent);
-		auto b = GetBValue(accent);
+        DWORD accent = Windows10AccentColor();
+        if (accent != -1)
+        {
+                //windows seems to be bgr, convert to rgb
+                auto r = GetRValue(accent);
+                auto g = GetGValue(accent);
+                auto b = GetBValue(accent);
 
-		m_clipPastedColor = RGB(b, g, r);
-		m_searchTextBoxFocusBorder = m_clipPastedColor;
-		m_searchTextHighlight = m_clipPastedColor;
+                m_clipPastedColor = RGB(b, g, r);
+                m_searchTextBoxFocusBorder = m_clipPastedColor;
+                m_searchTextHighlight = m_clipPastedColor;
 
-		//if (Windows10ColorTitleBar())
-		//{
-		//	m_CaptionRight = m_clipPastedColor;
-		//	m_CaptionLeft = m_clipPastedColor;
-		//	m_Border = m_clipPastedColor;
-		//}
-	}
+                //if (Windows10ColorTitleBar())
+                //{
+                //      m_CaptionRight = m_clipPastedColor;
+                //      m_CaptionLeft = m_clipPastedColor;
+                //      m_Border = m_clipPastedColor;
+                //}
+        }
 }
 
 bool CTheme::LoadColor(TiXmlElement *pParent, CStringA csNode, COLORREF &Color)
 {
-	int intValue = 0;
-	return LoadElement(pParent, csNode, Color, intValue);
+        int intValue = 0;
+        return LoadElement(pParent, csNode, Color, intValue);
 }
 
 bool CTheme::LoadInt(TiXmlElement *pParent, CStringA csNode, int &intValue)
 {
-	COLORREF colorValue = 0;
-	return LoadElement(pParent, csNode, colorValue, intValue);
+        COLORREF colorValue = 0;
+        return LoadElement(pParent, csNode, colorValue, intValue);
 }
 
 bool CTheme::LoadElement(TiXmlElement *pParent, CStringA csNode, COLORREF &Color, int &intValue)
 {
-	TiXmlElement *pColorNode = pParent->FirstChildElement(csNode);
-	if(pColorNode == NULL)
-	{
-		m_csLastError.Format(_T("Theme Load, error loading Node = %s"), csNode);
-		Log(m_csLastError);
-		return false;
-	}
+        TiXmlElement *pColorNode = pParent->FirstChildElement(csNode);
+        if (pColorNode == NULL)
+        {
+                m_csLastError.Format(_T("Theme Load, error loading Node = %s"), csNode);
+                Log(m_csLastError);
+                return false;
+        }
 
-	TiXmlNode *pColor = pColorNode->FirstChild();
-	if(pColor == NULL)
-	{
-		m_csLastError.Format(_T("Theme Load, error getting node text for = %s"), csNode);
-		Log(m_csLastError);
-		return false;
-	}
-	
-	CString csColor = pColor->Value();
+        TiXmlNode *pColor = pColorNode->FirstChild();
+        if (pColor == NULL)
+        {
+                m_csLastError.Format(_T("Theme Load, error getting node text for = %s"), csNode);
+                Log(m_csLastError);
+                return false;
+        }
 
-	if (csColor == _T(""))
-	{
-		return false;
-	}
+        CString csColor = pColor->Value();
 
-	// Convert "RGB" to lowercase to handle both "RGB" and "rgb"
-	csColor.MakeLower();
+        if (csColor == _T(""))
+        {
+                return false;
+        }
 
-	if (csColor.Find(_T("rgb")) >= 0)
-	{
-		csColor = csColor.Trim();
-		csColor.Replace(_T("rgb("), _T(""));
-		csColor.Replace(_T(")"), _T(""));
+        // Check for "RGB" case-insensitively
+        CString csColorUpper = csColor;
+        csColorUpper.MakeUpper();
+        if (csColorUpper.Find(_T("RGB")) >= 0)
+        {
+                csColor = csColor.Trim();
 
-		CTokenizer token(csColor, _T(","));
-		CString csR;
-		CString csG;
-		CString csB;
+                int openParen = csColor.Find('(');
+                int closeParen = csColor.Find(')');
 
-		token.Next(csR);
-		token.Next(csG);
-		token.Next(csB);
+                if (openParen != -1 && closeParen != -1 && closeParen > openParen)
+                {
+                        // Extract the content inside the parentheses
+                        csColor = csColor.Mid(openParen + 1, closeParen - openParen - 1);
+                }
+                else
+                {
+                        m_csLastError.Format(_T("Invalid RGB format in color: %s"), csColor);
+                        Log(m_csLastError);
+                        return false;
+                }
 
-		csR = csR.Trim();
-		csG = csG.Trim();
-		csB = csB.Trim();
+                CTokenizer token(csColor, _T(","));
+                CString csR;
+                CString csG;
+                CString csB;
 
-		//Only the first is valid they entered the RGB value as a single number
-		if (csR != "" && csG == "" && csB == "")
-		{
-			Color = ATOI(csR);
-		}
-		else
-		{
-			Color = RGB(ATOI(csR), ATOI(csG), ATOI(csB));
-		}
-	}
-	else
-	{
-		intValue = ATOI(csColor);
-	}
+                token.Next(csR);
+                token.Next(csG);
+                token.Next(csB);
 
-	return true;
+                csR = csR.Trim();
+                csG = csG.Trim();
+                csB = csB.Trim();
+
+                // Check if only the first value is valid (single number)
+                if (csR != _T("") && csG == _T("") && csB == _T(""))
+                {
+                        Color = ATOI(csR);
+                }
+                else
+                {
+                        Color = RGB(ATOI(csR), ATOI(csG), ATOI(csB));
+                }
+        }
+        else
+        {
+                intValue = ATOI(csColor);
+        }
+
+        return true;
 }

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -249,10 +249,13 @@ bool CTheme::LoadElement(TiXmlElement *pParent, CStringA csNode, COLORREF &Color
 		return false;
 	}
 
-	if (csColor.Find(_T("RGB")) >= 0)
+	// Convert "RGB" to lowercase to handle both "RGB" and "rgb"
+	csColor.MakeLower();
+
+	if (csColor.Find(_T("rgb")) >= 0)
 	{
 		csColor = csColor.Trim();
-		csColor.Replace(_T("RGB("), _T(""));
+		csColor.Replace(_T("rgb("), _T(""));
 		csColor.Replace(_T(")"), _T(""));
 
 		CTokenizer token(csColor, _T(","));


### PR DESCRIPTION
QListCtrl - Fix color match logic so that prefix (#, RGB, HSL, etc) is checked. Refactored.

Tweaked Monolight theme.

Allowed for lowercase RGB in Theme.cpp