### PR TITLE
Fix vanishing system tray icon

### DIFF
--- a/src/MainFrm.cpp
+++ b/src/MainFrm.cpp
@@ -725,10 +725,13 @@ void CMainFrame::OnTimer(UINT_PTR nIDEvent)
     switch(nIDEvent)
     {
         case HIDE_ICON_TIMER:
-            {
-				m_trayIcon.Hide();
-                KillTimer(nIDEvent);
-            }
+        	{
+            	KillTimer(nIDEvent);
+            	if (!CGetSetOptions::GetShowIconInSysTray())
+            	{
+                	m_trayIcon.Hide();
+            	}
+        }
 			break;
 
         case CLOSE_WINDOW_TIMER:


### PR DESCRIPTION
When Ditto starts, if "Display icon in system tray" option is disabled in the settings, we show tray icon for 40 seconds before hiding it.

## The Problem

The timer's handler in CMainFrame::OnTimer unconditionally hides the tray icon when it fires after 40 seconds. It does not re-check the current state of the "Display icon in system tray" option.

## Race Condition

If a user opens the options dialog within that 40-second window, enables the tray icon, and clicks "OK" or "Apply", the icon is correctly shown. However, the original 40-second timer is still active. When it fires, it executes m_trayIcon.Hide() regardless of the user's recent setting change, causing the icon to disappear unexpectedly.

## More?

I think there may be another issue which I haven't found but this fix seems reasonable. Tested and all good.